### PR TITLE
Fixed error in macro declaration

### DIFF
--- a/src/host/common/shared.hpp
+++ b/src/host/common/shared.hpp
@@ -22,7 +22,7 @@
 #define EXTENSION_RETURN() return;
 #endif
 
-#ifdef _WINDOWS
+#ifdef _WIN32
 #define sleep(x) Sleep(x)
 #endif
 


### PR DESCRIPTION
_WINDOWS was breaking the build. _WIN32 isn't