### PR TITLE
Fix Coverage reporting triggering a build failure

### DIFF
--- a/tools/conversion_coverage.py
+++ b/tools/conversion_coverage.py
@@ -9,8 +9,8 @@ def parse():
     projectpath = os.path.dirname(os.path.dirname(scriptpath))
     projectpath = os.path.join(projectpath, "src/client/intercept/client")
     projectpath_sqf = os.path.join(projectpath, "sqf")
-
-    declarations_file = os.path.join(projectpath, "sqf_pointers_declaration.hpp")
+    
+    declarations_file = os.path.join(os.path.dirname(os.path.dirname(scriptpath)), "src/client/headers/client/sqf_pointers_declaration.hpp")
 
     unary_functions = []
     binary_functions = []


### PR DESCRIPTION
#83 changed the path of the header files. This makes the coverage reporting script find the declarations of all sqf function pointers again.