### PR TITLE
Added path limiting to client module loading.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ rv/*.dll
 rv/carma_dll.*
 build
 vcproj
+rv/intercept

--- a/rv/addons/core/boot.sqf
+++ b/rv/addons/core/boot.sqf
@@ -48,5 +48,24 @@ _res = "intercept" callExtension format["init_patch:%1", (productVersion select 
     str parsingNamespace;
     "intercept" callExtension "invoker_end_register:";
 // };
-//"intercept" callExtension "load_extension:z\intercept\build\win32\example_frag\RelWithDebInfo\example_frag.dll";
+//"intercept" callExtension "load_extension:example_dll";
+
+_intercept_projects = configFile >> "Intercept";
+for "_i" from 0 to (count _intercept_projects)-1 do {
+    _project = _intercept_projects select _i;
+    if(isClass _project) then {
+        for "_x" from 0 to (count _project)-1 do {
+            _module = _project select _x;
+            if(isClass _module) then {
+                _plugin_name = getText(_module >> "pluginName");
+                if(_plugin_name != "") then {
+                    diag_log text format["Intercept Loading Plugin: %1", _plugin_name];
+                    "intercept" callExtension ("load_extension:" + _plugin_name);
+                };
+            };
+        };
+    };
+};
+
+
 //diag_log text format["_________________________________________Intercept Res: %1", _res];

--- a/rv/addons/core/config.cpp
+++ b/rv/addons/core/config.cpp
@@ -604,7 +604,15 @@ EH_CLASS_DEF(weapon_disassembled,weaponDisassembled);
 //EH_CLASS_DEF(task_set_as_current,taskSetAsCurrent);
 //EH_CLASS_DEF(weapon_deployed,weaponDeployed);
 //EH_CLASS_DEF(weapon_rested,weaponRested);
-
+/*
+class Intercept {
+    class example_dll_project {
+        class example_dll_module {
+            pluginName = "example_dll";
+        };
+    };
+};
+*/
 class CfgFunctions
 {
     class Intercept

--- a/rv/addons/core/lib.sqf
+++ b/rv/addons/core/lib.sqf
@@ -35,11 +35,10 @@ intercept_fnc__onFrame = {
 
 INVOKER_DELETE_ARRAY = [];
 INVOKER_DELETE_ARRAY resize 1000;
-intercept_params_var = [1,2,3];
-intercept_params_var resize 1000;
-intercept_params_index = 2;
+intercept_params_var = [1];
+intercept_params_var resize 2;
 intercept_signal_var = [];
-intercept_signal_var resize 1000;
+intercept_signal_var resize 2;
 str INVOKER_DELETE_ARRAY;
 
 diag_log text "Intercept Invoker SQF handler initializing...";

--- a/src/host/extensions/extensions.cpp
+++ b/src/host/extensions/extensions.cpp
@@ -70,7 +70,7 @@ namespace intercept {
 
         for (auto folder : _mod_folders) {
             std::string test_path = folder + "\\intercept\\" + path + ".dll";
-            LOG(INFO) << "Mod: " << test_path;
+            LOG(DEBUG) << "Mod: " << test_path;
             std::ifstream check_file(test_path);
             if (check_file.good()) {
                 full_path = test_path;

--- a/src/host/extensions/extensions.cpp
+++ b/src/host/extensions/extensions.cpp
@@ -57,6 +57,15 @@ namespace intercept {
             return true;
         }
 
+        std::string bad_chars = ".\\/:?\"<>|";
+        for (auto it = path.begin(); it < path.end(); ++it) {
+            bool found = bad_chars.find(*it) != std::string::npos;
+            if (found) {
+                LOG(ERROR) << "Client plugin: " << path << " contains illegal characters in its name.";
+                return false;
+            }
+        }
+
         std::string full_path = "";
 
         for (auto folder : _mod_folders) {

--- a/src/host/extensions/extensions.cpp
+++ b/src/host/extensions/extensions.cpp
@@ -2,6 +2,7 @@
 #include "controller.hpp"
 #include "export.hpp"
 
+
 namespace intercept {
 
     extensions::extensions() {
@@ -22,6 +23,14 @@ namespace intercept {
         functions.invoke_raw_unary_nolock = client_function_defs::invoke_raw_unary_nolock;
         functions.invoker_lock = client_function_defs::invoker_lock;
         functions.invoker_unlock = client_function_defs::invoker_unlock;
+        for (auto file : _searcher.active_pbo_list()) {
+            size_t last_index = file.find_last_of("\\/");
+            std::string path = file.substr(0, last_index);
+            last_index = path.find_last_of("\\/");
+            path = path.substr(0, last_index);
+            _mod_folders.push_back(path);
+        }
+        _mod_folders.unique();
     }
 
     extensions::~extensions() {
@@ -40,23 +49,40 @@ namespace intercept {
 
     bool extensions::load(const arguments & args_, std::string & result) {
         HMODULE dllHandle;
-
+        std::string path = args_.as_string(0);
         LOG(INFO) << "Load requested [" << args_.as_string(0) << "]";
-        std::string args = GetCommandLineA();
 
-        if (_modules.find(args_.as_string(0)) != _modules.end()) {
-            LOG(ERROR) << "Module already loaded [" << args_.as_string(0) << "]";
+        if (_modules.find(path) != _modules.end()) {
+            LOG(ERROR) << "Module already loaded [" << path << "]";
             return true;
         }
 
-        dllHandle = LoadLibrary(args_.as_string(0).c_str());
-        if (!dllHandle) {
-            LOG(ERROR) << "LoadLibrary() failed, e=" << GetLastError() << " [" << args_.as_string(0) << "]";
+        std::string full_path = "";
+
+        for (auto folder : _mod_folders) {
+            std::string test_path = folder + "\\intercept\\" + path + ".dll";
+            LOG(INFO) << "Mod: " << test_path;
+            std::ifstream check_file(test_path);
+            if (check_file.good()) {
+                full_path = test_path;
+                break;
+            }
+        }
+        if (full_path == "") {
+            LOG(ERROR) << "Client plugin: " << path << " was not found.";
             return false;
         }
 
 
-        auto new_module = module::entry(args_.as_string(0), dllHandle);
+
+        dllHandle = LoadLibrary(full_path.c_str());
+        if (!dllHandle) {
+            LOG(ERROR) << "LoadLibrary() failed, e=" << GetLastError() << " [" << full_path << "]";
+            return false;
+        }
+
+
+        auto new_module = module::entry(full_path, dllHandle);
 
         new_module.functions.api_version = (module::api_version_func)GetProcAddress(dllHandle, "api_version");
         new_module.functions.assign_functions = (module::assign_functions_func)GetProcAddress(dllHandle, "assign_functions");
@@ -116,19 +142,19 @@ namespace intercept {
 
 
         if (!new_module.functions.api_version) {
-            LOG(ERROR) << "Module " << args_.as_string(0) << " failed to define the api_version function.";
+            LOG(ERROR) << "Module " << path << " failed to define the api_version function.";
             return false;
         }
 
         if (!new_module.functions.assign_functions) {
-            LOG(ERROR) << "Module " << args_.as_string(0) << " failed to define the assign_functions function.";
+            LOG(ERROR) << "Module " << path << " failed to define the assign_functions function.";
             return false;
         }
 
         new_module.functions.assign_functions(functions);
 
-        _modules[args_.as_string(0)] = new_module;
-        LOG(INFO) << "Load completed [" << args_.as_string(0) << "]";
+        _modules[path] = new_module;
+        LOG(INFO) << "Load completed [" << path << "]";
         return false;
     }
 

--- a/src/host/extensions/extensions.hpp
+++ b/src/host/extensions/extensions.hpp
@@ -16,6 +16,8 @@ https://github.com/NouberNou/intercept
 #include "shared\functions.hpp"
 #include "shared\client_types.hpp"
 
+#include "search.hpp"
+
 namespace intercept {
     /*!
     @namespace
@@ -244,5 +246,9 @@ namespace intercept {
         @brief The map of all loaded modules.
         */
         std::unordered_map<std::string, module::entry> _modules;
+
+        intercept::pbo::search _searcher;
+
+        std::list<std::string> _mod_folders;
     };
 };

--- a/src/host/extensions/search.cpp
+++ b/src/host/extensions/search.cpp
@@ -1,0 +1,286 @@
+#include "search.hpp"
+#include <sstream>
+#include <iterator>
+#include <algorithm>
+#include <regex>
+
+#define NT_SUCCESS(x) ((x) >= 0)
+#define STATUS_INFO_LENGTH_MISMATCH 0xc0000004
+
+#define SystemHandleInformation 16
+#define SystemHandleInformationEx 64
+
+#define ObjectBasicInformation 0
+#define ObjectNameInformation 1
+#define ObjectTypeInformation 2
+
+typedef NTSTATUS(NTAPI *_NtQuerySystemInformation)(
+    ULONG SystemInformationClass,
+    PVOID SystemInformation,
+    ULONG SystemInformationLength,
+    PULONG ReturnLength
+    );
+typedef NTSTATUS(NTAPI *_NtDuplicateObject)(
+    HANDLE SourceProcessHandle,
+    HANDLE SourceHandle,
+    HANDLE TargetProcessHandle,
+    PHANDLE TargetHandle,
+    ACCESS_MASK DesiredAccess,
+    ULONG Attributes,
+    ULONG Options
+    );
+typedef NTSTATUS(NTAPI *_NtQueryObject)(
+    HANDLE ObjectHandle,
+    ULONG ObjectInformationClass,
+    PVOID ObjectInformation,
+    ULONG ObjectInformationLength,
+    PULONG ReturnLength
+    );
+
+typedef struct _UNICODE_STRING
+{
+    USHORT Length;
+    USHORT MaximumLength;
+    PWSTR Buffer;
+} UNICODE_STRING, *PUNICODE_STRING;
+
+typedef struct _SYSTEM_HANDLE
+{
+    ULONG ProcessId;
+    BYTE ObjectTypeNumber;
+    BYTE Flags;
+    USHORT Handle;
+    PVOID Object;
+    ACCESS_MASK GrantedAccess;
+} SYSTEM_HANDLE, *PSYSTEM_HANDLE;
+
+typedef struct _SYSTEM_HANDLE_EX
+{
+	PVOID Object;
+	HANDLE ProcessId;
+	HANDLE Handle;
+	ULONG GrantedAccess;
+	USHORT CreatorBackTraceIndex;
+	USHORT ObjectTypeIndex;
+	ULONG HandleAttributes;
+	ULONG Reserved;
+} SYSTEM_HANDLE_EX, *PSYSTEM_HANDLE_EX;
+
+typedef struct _SYSTEM_HANDLE_INFORMATION
+{
+    ULONG HandleCount;
+    SYSTEM_HANDLE Handles[1];
+} SYSTEM_HANDLE_INFORMATION, *PSYSTEM_HANDLE_INFORMATION;
+
+typedef struct _SYSTEM_HANDLE_INFORMATION_EX
+{
+	ULONG_PTR HandleCount;
+	ULONG_PTR Reserved;
+	SYSTEM_HANDLE_EX Handles[1];
+} SYSTEM_HANDLE_INFORMATION_EX, *PSYSTEM_HANDLE_INFORMATION_EX;
+
+typedef enum _POOL_TYPE
+{
+    NonPagedPool,
+    PagedPool,
+    NonPagedPoolMustSucceed,
+    DontUseThisType,
+    NonPagedPoolCacheAligned,
+    PagedPoolCacheAligned,
+    NonPagedPoolCacheAlignedMustS
+} POOL_TYPE, *PPOOL_TYPE;
+
+typedef struct _OBJECT_TYPE_INFORMATION
+{
+    UNICODE_STRING Name;
+    ULONG TotalNumberOfObjects;
+    ULONG TotalNumberOfHandles;
+    ULONG TotalPagedPoolUsage;
+    ULONG TotalNonPagedPoolUsage;
+    ULONG TotalNamePoolUsage;
+    ULONG TotalHandleTableUsage;
+    ULONG HighWaterNumberOfObjects;
+    ULONG HighWaterNumberOfHandles;
+    ULONG HighWaterPagedPoolUsage;
+    ULONG HighWaterNonPagedPoolUsage;
+    ULONG HighWaterNamePoolUsage;
+    ULONG HighWaterHandleTableUsage;
+    ULONG InvalidAttributes;
+    GENERIC_MAPPING GenericMapping;
+    ULONG ValidAccess;
+    BOOLEAN SecurityRequired;
+    BOOLEAN MaintainHandleCount;
+    USHORT MaintainTypeList;
+    POOL_TYPE PoolType;
+    ULONG PagedPoolUsage;
+    ULONG NonPagedPoolUsage;
+} OBJECT_TYPE_INFORMATION, *POBJECT_TYPE_INFORMATION;
+
+PVOID GetLibraryProcAddress(PSTR LibraryName, PSTR ProcName)
+{
+    return GetProcAddress(GetModuleHandleA(LibraryName), ProcName);
+}
+
+namespace intercept {
+    namespace pbo {
+
+        search::search() {
+            generate_pbo_list();
+        }
+
+        bool search::generate_pbo_list() {
+            NTSTATUS status;
+            PSYSTEM_HANDLE_INFORMATION_EX handleInfo;
+            ULONG handleInfoSize = 0x10000;
+            HANDLE pid;
+            HANDLE processHandle;
+            ULONG i;
+
+            _NtQuerySystemInformation NtQuerySystemInformation =
+                (_NtQuerySystemInformation)GetLibraryProcAddress("ntdll.dll", "NtQuerySystemInformation");
+            _NtDuplicateObject NtDuplicateObject =
+                (_NtDuplicateObject)GetLibraryProcAddress("ntdll.dll", "NtDuplicateObject");
+            _NtQueryObject NtQueryObject =
+                (_NtQueryObject)GetLibraryProcAddress("ntdll.dll", "NtQueryObject");
+
+            if (!NtQuerySystemInformation || !NtDuplicateObject || !NtQueryObject)
+                return false;
+
+            pid = (HANDLE)GetCurrentProcessId();
+            processHandle = (HANDLE)GetCurrentProcess();
+
+            handleInfo = (PSYSTEM_HANDLE_INFORMATION_EX)malloc(handleInfoSize);
+            while ((status = NtQuerySystemInformation(
+				SystemHandleInformationEx,
+                handleInfo,
+                handleInfoSize,
+                NULL
+                )) == STATUS_INFO_LENGTH_MISMATCH)
+                handleInfo = (PSYSTEM_HANDLE_INFORMATION_EX)realloc(handleInfo, handleInfoSize *= 2);
+
+            /* NtQuerySystemInformation stopped giving us STATUS_INFO_LENGTH_MISMATCH. */
+            if (!NT_SUCCESS(status))
+            {
+                //LOG(ERROR) << "Error opening object for pbo search";
+                free(handleInfo);
+                return false;
+            }
+			//LOG(INFO) << "Handles obtained!";
+            for (i = 0; i < handleInfo->HandleCount; i++)
+            {
+                SYSTEM_HANDLE_EX handle = handleInfo->Handles[i];
+                HANDLE dupHandle = NULL;
+                POBJECT_TYPE_INFORMATION objectTypeInfo;
+                PVOID objectNameInfo;
+                UNICODE_STRING objectName;
+                ULONG returnLength;
+
+                /* Check if this handle belongs to the PID the user specified. */
+				if (handle.ProcessId != pid) {
+					//LOG(INFO) << "PID MISMATCH: " << (DWORD)handle.ProcessId << " != " << (DWORD)pid;
+					continue;
+				}
+                    
+
+                /* Duplicate the handle so we can query it. */
+                if (!NT_SUCCESS(NtDuplicateObject(
+                    processHandle,
+                    (HANDLE)handle.Handle,
+                    GetCurrentProcess(),
+                    &dupHandle,
+                    0,
+                    0,
+                    0
+                    )))
+                {
+					//LOG(INFO) << "FAILED TO DUPLICATE OJBECT";
+                    continue;
+                }
+
+                /* Query the object type. */
+                objectTypeInfo = (POBJECT_TYPE_INFORMATION)malloc(0x1000);
+                if (!NT_SUCCESS(NtQueryObject(
+                    dupHandle,
+                    ObjectTypeInformation,
+                    objectTypeInfo,
+                    0x1000,
+                    NULL
+                    )))
+                {
+					//LOG(INFO) << "FAILED TO QUERY OJBECT";
+                    CloseHandle(dupHandle);
+                    continue;
+                }
+
+                /* Query the object name (unless it has an access of
+                0x0012019f, on which NtQueryObject could hang. */
+                if (handle.GrantedAccess == 0x0012019f)
+                {
+					//LOG(INFO) << "ACCESS == 0x0012019f";
+                    free(objectTypeInfo);
+                    CloseHandle(dupHandle);
+                    continue;
+                }
+
+                objectNameInfo = malloc(0x1000);
+                if (!NT_SUCCESS(NtQueryObject(
+                    dupHandle,
+                    ObjectNameInformation,
+                    objectNameInfo,
+                    0x1000,
+                    &returnLength
+                    )))
+                {
+					//LOG(INFO) << "THE FUCK...";
+                    /* Reallocate the buffer and try again. */
+                    objectNameInfo = realloc(objectNameInfo, returnLength);
+                    if (!NT_SUCCESS(NtQueryObject(
+                        dupHandle,
+                        ObjectNameInformation,
+                        objectNameInfo,
+                        returnLength,
+                        NULL
+                        )))
+                    {
+						//LOG(INFO) << "... IS THIS SHIT?";
+                        free(objectTypeInfo);
+                        free(objectNameInfo);
+                        CloseHandle(dupHandle);
+                        continue;
+                    }
+                }
+
+                /* Cast our buffer into an UNICODE_STRING. */
+                objectName = *(PUNICODE_STRING)objectNameInfo;
+               
+                
+
+                /* Print the information! */
+                if (objectName.Length)
+                {
+                    std::wstring tmp_type(objectTypeInfo->Name.Buffer);
+                    std::wstring tmp_name(objectName.Buffer);
+                    
+                    std::string object_type(tmp_type.begin(), tmp_type.end());
+                    std::string object_name(tmp_name.begin(), tmp_name.end());
+					//LOG(INFO) << "File: " << object_name;
+                    if (object_type == "File" && object_name.find(".pbo") != object_name.npos) {
+                        char buffer[MAX_PATH];
+                        GetFinalPathNameByHandle(dupHandle, buffer, sizeof(buffer), VOLUME_NAME_DOS);
+
+                        //LOG(INFO) << "Pbo: " << buffer;
+                        _active_pbo_list.push_back(std::string(buffer));
+                    }
+				}
+
+                free(objectTypeInfo);
+                free(objectNameInfo);
+                CloseHandle(dupHandle);
+            }
+
+            free(handleInfo);
+
+            return true;
+        }
+    }
+}

--- a/src/host/extensions/search.hpp
+++ b/src/host/extensions/search.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "shared.hpp"
+
+namespace intercept { 
+    namespace pbo {
+        class search {
+        public:
+            search();
+            const std::vector<std::string> & active_pbo_list() { return _active_pbo_list;  }
+        protected:
+            bool generate_pbo_list();
+
+            std::vector<std::string> _active_pbo_list;
+        };
+        typedef std::shared_ptr<search> search_p;
+    }
+}


### PR DESCRIPTION
Client plugins are now limited to being loaded from specific mod folders, in which they will have a folder called intercept. That folder will contain plugin dlls. Plugins are referred to by their dll name, minus the file extension.

For example:

`"intercept" callExtension "load_extension:example_dll";`