### PR TITLE
Fix crash with Arma v1.68.

### DIFF
--- a/src/host/loader/loader.cpp
+++ b/src/host/loader/loader.cpp
@@ -172,15 +172,18 @@ namespace intercept {
             uint32_t placeholder5;//0x14
             uint32_t placeholder6;//0x18
             uint32_t placeholder7;//0x1C
-            const rv_string* _name2;//0x20 this is (tolower name)
-            unary_operator * _operator;//0x24
-            uint32_t placeholder8;//0x28 RString to something
-            const rv_string* _description;//0x2C
+            uint32_t placeholder8;//0x20
+            uint32_t placeholder9;//0x24
+            const rv_string* _name2;//0x28 this is (tolower name)
+            unary_operator * _operator;//0x2C
+            uint32_t placeholder10;//0x30 RString to something
+            const rv_string* _description;//0x34
             const rv_string* _example;
             const rv_string* _example2;
-            const rv_string* placeholder9;
-            const rv_string* placeholder10;
-            const rv_string* _category; //0x40
+            const rv_string* placeholder11;
+            const rv_string* placeholder12;
+            const rv_string* _category; //0x48
+            //const rv_string* placeholder13;
         };
         struct gsOperator {
             const  rv_string* _name;
@@ -191,17 +194,19 @@ namespace intercept {
             uint32_t placeholder5;//0x14
             uint32_t placeholder6;//0x18
             uint32_t placeholder7;//0x1C
-            const rv_string* _name2;//0x20 this is (tolower name)
-            int32_t placeholder8; //0x24 Small int 0-5
-            binary_operator * _operator;//0x28
-            const rv_string* _leftType;//0x2C Description of left hand side parameter
-            const rv_string* _rightType;//0x30 Description of right hand side parameter
-            const rv_string* _description;//0x34
-            const rv_string* _example;//0x38
-            const rv_string* placeholder10;//0x3C
-            const rv_string* _version;//0x40 some version number
+            uint32_t placeholder8;//0x20
+            uint32_t placeholder9;//0x24
+            const rv_string* _name2;//0x28 this is (tolower name)
+            int32_t placeholder10; //0x2C Small int 0-5
+            binary_operator * _operator;//0x30
+            const rv_string* _leftType;//0x34 Description of left hand side parameter
+            const rv_string* _rightType;//0x38 Description of right hand side parameter
+            const rv_string* _description;//0x3C
+            const rv_string* _example;//0x40
             const rv_string* placeholder11;//0x44
-            const rv_string* _category; //0x48
+            const rv_string* _version;//0x48 some version number
+            const rv_string* placeholder12;//0x4C
+            const rv_string* _category; //0x50
         };
 		struct gsNular {
             const rv_string* _name;
@@ -211,15 +216,17 @@ namespace intercept {
             uint32_t placeholder4;//0x10
             uint32_t placeholder5;//0x14
             uint32_t placeholder6;//0x18
-            const rv_string* _name2;//0x1C this is (tolower name)
-            nular_operator * _operator;//0x20
-            const rv_string* _description;//0x24
+            uint32_t placeholder7;//0x1C -- change
+            uint32_t placeholder8;//0x20
+            const rv_string* _name2;//0x24 this is (tolower name)
+            nular_operator * _operator;//0x28
+            const rv_string* _description;//0x2C
             const rv_string* _example;
             const rv_string* _example2;
-            const rv_string* _version;//0x30 some version number
+            const rv_string* _version;//0x38 some version number
             const rv_string* placeholder10;
-            const rv_string* _category; //0x38
-            uint32_t placeholder11;//0x3C
+            const rv_string* _category; //0x40
+            uint32_t placeholder11;//0x44
         };
 
 
@@ -229,9 +236,9 @@ namespace intercept {
 
     
     void loader::do_function_walk(uintptr_t state_addr_) {
-        uintptr_t unary_hash = state_addr_ + 16;
-        uintptr_t binary_hash = state_addr_ + 28;
-        uintptr_t nulars_hash = state_addr_ + 40;
+        uintptr_t unary_hash = state_addr_ + 0xC;
+        uintptr_t binary_hash = state_addr_ + 0x18;
+        uintptr_t nulars_hash = state_addr_ + 0x24;
 
         /*
         Unary Hashmap
@@ -252,14 +259,12 @@ namespace intercept {
 
             for (uint32_t entry_offset = 0; entry_offset < bucket_length; ++entry_offset) {
 
-                uint32_t op_count = *(uintptr_t *)(entry_start + (0x2C * entry_offset) + 4);
-                __internal::gsFunction* op_start = *(__internal::gsFunction**)(entry_start + (0x2C * entry_offset));
+                uint32_t op_count = *(uintptr_t *)(entry_start + (0x34 * entry_offset) + 4);
+                __internal::gsFunction* op_start = *(__internal::gsFunction**)(entry_start + (0x34 * entry_offset));
                 for (uint32_t op_offset = 0; op_offset < op_count; ++op_offset) {
-                    uintptr_t entry2 = ((uintptr_t)op_start + (0x44 * op_offset));
                     __internal::gsFunction& entry = op_start[op_offset];
                     unary_entry new_entry;
                     new_entry.op = entry._operator;
-                    new_entry.procedure_ptr_addr = (*(uintptr_t *)(entry2 + 0x24)) + 8;
                     new_entry.procedure_ptr_addr = (uintptr_t) &entry._operator->procedure_addr;
                     const rv_string* name_entry = entry._name;
                     new_entry.name = &(name_entry->char_string);
@@ -290,8 +295,8 @@ namespace intercept {
             uintptr_t entry_start = *(uintptr_t *)bucket;
 
             for (uint32_t entry_offset = 0; entry_offset < bucket_length; ++entry_offset) {
-                uint32_t op_count = *(uintptr_t *)(entry_start + (0x30 * entry_offset) + 4);
-                __internal::gsOperator* op_start = *(__internal::gsOperator**)(entry_start + (0x30 * entry_offset));
+                uint32_t op_count = *(uintptr_t *)(entry_start + (0x38 * entry_offset) + 4);
+                __internal::gsOperator* op_start = *(__internal::gsOperator**)(entry_start + (0x38 * entry_offset));
                 for (uint32_t op_offset = 0; op_offset < op_count; ++op_offset) {
                     __internal::gsOperator& entry = op_start[op_offset];
                    // uintptr_t entry = (op_start + (0x4C * op_offset));


### PR DESCRIPTION
There seem to be many changes, at first sight, but they boil down to adding two `placeholder` variables at the start of `gs*` structures and fixing some structures' sizes.

The other changes stem from the offsets in the comments that have all changed. Maybe these comments should be removed in the future.