### PR TITLE
Fix the "cannot convert from 'initializer list' to 'rv_color'" error.

### DIFF
--- a/src/client/headers/client/sqf/uncategorized.hpp
+++ b/src/client/headers/client/sqf/uncategorized.hpp
@@ -84,6 +84,14 @@ namespace intercept {
                 alpha(ret_game_value_[3])
             {
             }
+
+            rv_color(float red_, float blue_, float green_, float alpha_) :
+                red(red_),
+                blue(blue_),
+                green(green_),
+                alpha(alpha_)
+            {
+            }
         };
 
         struct rv_resolution {


### PR DESCRIPTION
That's an error that shows as soon as you want to compile the example plugins.

Note: the order of this constructor is RBGA which is consistent with what has already been written in the file but this looks like a bug to me (shouldn't all of those constructors use RGBA instead?)