### PR TITLE
rv_color order should be RGBA

### DIFF
--- a/src/client/headers/client/sqf/uncategorized.hpp
+++ b/src/client/headers/client/sqf/uncategorized.hpp
@@ -55,15 +55,15 @@ namespace intercept {
 
         struct rv_color {
             float red;
-            float blue;
             float green;
+            float blue;
             float alpha;
 
             operator game_value() {
                 return game_value(std::vector<game_value>({
                     red,
-                    blue,
                     green,
+                    blue,
                     alpha
                 }));
             }
@@ -71,24 +71,24 @@ namespace intercept {
             operator game_value() const {
                 return game_value(std::vector<game_value>({
                     red,
-                    blue,
                     green,
+                    blue,
                     alpha
                 }));
             }
 
             rv_color(const game_value &ret_game_value_) :
                 red(ret_game_value_[0]),
-                blue(ret_game_value_[1]),
-                green(ret_game_value_[2]),
+                green(ret_game_value_[1]),
+                blue(ret_game_value_[2]),
                 alpha(ret_game_value_[3])
             {
             }
 
-            rv_color(float red_, float blue_, float green_, float alpha_) :
+            rv_color(float red_, float green_, float blue_, float alpha_) :
                 red(red_),
-                blue(blue_),
                 green(green_),
+                blue(blue_),
                 alpha(alpha_)
             {
             }

--- a/src/client/headers/client/sqf/uncategorized.hpp
+++ b/src/client/headers/client/sqf/uncategorized.hpp
@@ -84,6 +84,14 @@ namespace intercept {
                 alpha(ret_game_value_[3])
             {
             }
+
+            rv_color(float red_, float blue_, float green_, float alpha_) :
+                red(red_),
+                blue(blue_),
+                green(green_),
+                alpha(alpha_)
+            {
+            }
         };
 
         struct rv_resolution {


### PR DESCRIPTION
The color order of rv_color is stored internally as RBGA, which is probably a bug.

This will work fine as long as all the values are passed at once because the `game_value` operator uses the same order as the constructor but if someone wants to access particular color components, they will access the wrong components.

This PR assumes PR #117 has already been merged.