### PR TITLE
Allocator Overhaul

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ rv/intercept.pdb
 !.gitkeep
 vcproj/*
 !vcproj/.gitkeep
+.vs

--- a/src/client/headers/intercept.hpp
+++ b/src/client/headers/intercept.hpp
@@ -18,32 +18,32 @@ namespace intercept {
         DLLEXPORT void __cdecl on_signal(std::string &signal_name_, game_value& value1_);
 
 #define EH(x) DLLEXPORT void __cdecl x
-
-        EH(anim_changed)(object &unit_, rv_string &anim_name_);
-        EH(anim_done)(object &unit_, rv_string &anim_name_);
-        EH(anim_state_changed)(object &unit_, rv_string &anim_name_);
+         //#TODO may want r_string& here
+        EH(anim_changed)(object &unit_, r_string anim_name_);
+        EH(anim_done)(object &unit_, r_string anim_name_);
+        EH(anim_state_changed)(object &unit_, r_string anim_name_);
         EH(container_closed)(object &container_, object &player_);
         EH(controls_shifted)(object &vehicle_, object &new_controller_, object &old_controller_);
-        EH(dammaged)(object &unit_, rv_string &selection_name_, float damage_);
+        EH(dammaged)(object &unit_, r_string &selection_name_, float damage_);
         EH(engine)(object &vehicle_, bool engine_state_);
-        EH(epe_contact)(object &object1_, object &object2_, rv_string &selection1_, rv_string &selection2_, float force_);
-        EH(epe_contact_end)(object &object1_, object &object2_, rv_string &selection1_, rv_string &selection2_, float force_);
-        EH(epe_contact_start)(object &object1_, object &object2_, rv_string &selection1_, rv_string &selection2_, float force_);
+        EH(epe_contact)(object &object1_, object &object2_, r_string selection1_, r_string selection2_, float force_);
+        EH(epe_contact_end)(object &object1_, object &object2_, r_string selection1_, r_string selection2_, float force_);
+        EH(epe_contact_start)(object &object1_, object &object2_, r_string selection1_, r_string selection2_, float force_);
         EH(explosion)(object &vehicle_, float damage_);
-        EH(fired)(object &unit_, rv_string &weapon_, rv_string &muzzle_, rv_string &mode_, rv_string &ammo_, rv_string &magazine, object &projectile_);
-        EH(fired_near)(object &unit_, object &firer_, float distance_, rv_string &weapon_, rv_string &muzzle_, rv_string &mode_, rv_string &ammo_);
+        EH(fired)(object &unit_, r_string weapon_, r_string muzzle_, r_string mode_, r_string ammo_, r_string magazine, object &projectile_);
+        EH(fired_near)(object &unit_, object &firer_, float distance_, r_string weapon_, r_string muzzle_, r_string mode_, r_string ammo_);
         EH(fuel)(object &vehicle_, bool fuel_state_);
         EH(gear)(object &vehicle_, bool gear_state_);
         EH(get_in)(object &vehicle_, rv_string position_, object &unit_, rv_list<int> &turret_path);
         EH(get_out)(object &vehicle_, rv_string position_, object &unit_, rv_list<int> &turret_path);
-        EH(handle_damage)(object &unit_, rv_string &selection_name_, float damage_, object &source_, rv_string &projectile_, int hit_part_index_);
+        EH(handle_damage)(object &unit_, r_string selection_name_, float damage_, object &source_, r_string projectile_, int hit_part_index_);
         EH(handle_heal)(object &unit_, object &healder_, bool healer_can_heal_);
         EH(handle_rating)(object &unit_, float rating_);
         EH(handle_score)(object &unit_, object &object_, float score_);
         EH(hit)(object &unit_, object &caused_by_, float damage_);
         EH(hit_part)(rv_list<hit_part_data> &data_);
         EH(init)(object &unit_);
-        EH(incoming_missile)(object &unit_, rv_string &ammo_, object &firer_);
+        EH(incoming_missile)(object &unit_, r_string ammo_, object &firer_);
         EH(inventory_closed)(object &object_, object &container_);
         EH(inventory_opened)(object &object_, object &container_);
         EH(killed)(object &unit_, object &killer_);
@@ -57,7 +57,7 @@ namespace intercept {
         EH(rope_break)(object &object1, object &rope_, object &object2_);
         EH(seat_switched)(object &vehicle_, object &unit1_, object &unit2_);
         EH(sound_played)(object &unit_, int sound_code_);
-        EH(take)(object &unit_, object &container_, rv_string &item_);
+        EH(take)(object &unit_, object &container_, r_string item_);
         EH(task_set_as_current)(object &unit_, task &task_);
         EH(weapon_assembled)(object &unit_, object &weapon_);
         EH(weapon_disassembled)(object &unit_, object &primary_bag_, object &secondary_bag_);

--- a/src/client/headers/shared/functions.hpp
+++ b/src/client/headers/shared/functions.hpp
@@ -109,6 +109,14 @@ namespace intercept {
             void(*invoker_lock)();
             void(*invoker_unlock)();
 
+            /*!
+            @brief Get's a pointer to Arma's memory allocator
+
+            This returns a pointer to Arma's internal memory allocator for use by rv_allocator
+
+            @param value_ A pointer to the allocator
+            */
+            uintptr_t(*get_engine_allocator)();
         };
     }
 }

--- a/src/client/headers/shared/functions.hpp
+++ b/src/client/headers/shared/functions.hpp
@@ -116,7 +116,7 @@ namespace intercept {
 
             @param value_ A pointer to the allocator
             */
-            uintptr_t(*get_engine_allocator)();
+            const types::__internal::allocatorInfo*(*get_engine_allocator)();
         };
     }
 }

--- a/src/client/headers/shared/pool.hpp
+++ b/src/client/headers/shared/pool.hpp
@@ -7,26 +7,29 @@ namespace intercept {
     class game_data_pool {
     public:
         game_data_pool() {
-            for (std::size_t i = 0; i < Size; ++i)
-                _buy_entry();
+            //for (std::size_t i = 0; i < Size; ++i)
+            //    _buy_entry();
         }
 
         inline T * acquire() {
+            return nullptr;// rv_allocator<T>::allocate(1);
+            /*
             if (_pool_queue.size() == 0)
                 _buy_entry();
             T * ret = _pool_queue.front();
             _pool_queue.pop();
-            return ret;
+            return ret; */
         }
 
         inline void release(T *_ptr) {
-            memset((void *)_ptr, 0xcdf3cdde, sizeof(T));
-            _pool_queue.push(_ptr);
+            //rv_allocator<T>::deallocate(_ptr);
+            //memset((void *)_ptr, 0xcdf3cdde, sizeof(T));
+            //_pool_queue.push(_ptr);
         }
         
         ~game_data_pool() {
-            for (auto entry : _pool)
-                free(entry);
+            //for (auto entry : _pool)
+            //    free(entry);
         }
 
         game_data_pool(const game_data_pool &) = delete;
@@ -49,33 +52,41 @@ namespace intercept {
     class game_data_array_pool {
     public:
         game_data_array_pool() {
-            for (std::size_t i = 0; i < Size; ++i)
-                _buy_entry(Alloc_Count);
+            //for (std::size_t i = 0; i < Size; ++i)
+            //    _buy_entry(Alloc_Count);
         }
 
         inline T * acquire(std::size_t alloc_count_) {
+            return nullptr;// rv_allocator<T>::allocate(alloc_count_);
+
+             /*
             if (_pool_queue.size() == 0 || alloc_count_ > Alloc_Count)
                 _buy_entry(alloc_count_);                
             T * ret = _pool_queue.front();
             std::size_t *count = (std::size_t *)((char *)ret - sizeof(std::size_t));
             *count = alloc_count_;
             _pool_queue.pop();
-            return ret;
+            return ret; */
         }
 
         inline void release(T *_ptr) {
+           // return rv_allocator<T>::deallocate(_ptr);
+            /*
             std::size_t *count = (std::size_t *)((char *)_ptr - sizeof(std::size_t));
             for (std::size_t i = 0; i < *count; ++i)
                 _ptr[i].~T();
             *count = 0;
             _pool_queue.push(_ptr);
+            */
         }
 
         ~game_data_array_pool() {
+            /*
             for (auto entry : _pool) {
                 release((T *)(entry + sizeof(std::size_t)));
                 free((void *)entry);
             }
+            */
         }
 
         game_data_array_pool(const game_data_array_pool &) = delete;

--- a/src/client/headers/shared/pool.hpp
+++ b/src/client/headers/shared/pool.hpp
@@ -10,15 +10,13 @@ namespace intercept {
             //for (std::size_t i = 0; i < Size; ++i)
             //    _buy_entry();
         }
-
+        /*
         inline T * acquire() {
-            return nullptr;// rv_allocator<T>::allocate(1);
-            /*
             if (_pool_queue.size() == 0)
                 _buy_entry();
             T * ret = _pool_queue.front();
             _pool_queue.pop();
-            return ret; */
+            return ret;
         }
 
         inline void release(T *_ptr) {
@@ -26,7 +24,7 @@ namespace intercept {
             //memset((void *)_ptr, 0xcdf3cdde, sizeof(T));
             //_pool_queue.push(_ptr);
         }
-        
+        */
         ~game_data_pool() {
             //for (auto entry : _pool)
             //    free(entry);
@@ -55,31 +53,26 @@ namespace intercept {
             //for (std::size_t i = 0; i < Size; ++i)
             //    _buy_entry(Alloc_Count);
         }
-
+          /*
         inline T * acquire(std::size_t alloc_count_) {
-            return nullptr;// rv_allocator<T>::allocate(alloc_count_);
-
-             /*
             if (_pool_queue.size() == 0 || alloc_count_ > Alloc_Count)
                 _buy_entry(alloc_count_);                
             T * ret = _pool_queue.front();
             std::size_t *count = (std::size_t *)((char *)ret - sizeof(std::size_t));
             *count = alloc_count_;
             _pool_queue.pop();
-            return ret; */
+            return ret;
         }
 
         inline void release(T *_ptr) {
-           // return rv_allocator<T>::deallocate(_ptr);
-            /*
             std::size_t *count = (std::size_t *)((char *)_ptr - sizeof(std::size_t));
             for (std::size_t i = 0; i < *count; ++i)
                 _ptr[i].~T();
             *count = 0;
             _pool_queue.push(_ptr);
-            */
+ 
         }
-
+        */
         ~game_data_array_pool() {
             /*
             for (auto entry : _pool) {

--- a/src/client/headers/shared/types.hpp
+++ b/src/client/headers/shared/types.hpp
@@ -63,7 +63,7 @@ namespace intercept {
                 char* arr[6]{ "tbb4malloc_bi","tbb3malloc_bi","jemalloc_bi","tcmalloc_bi","nedmalloc_bi","custommalloc_bi" };
             };
         public:
-            static void deallocate(Type* _Ptr, size_t);
+            static void deallocate(Type* _Ptr, size_t _unused = 0); //#TODO if its unused why not just remove it?!
             static Type* allocate(size_t _count);
 
             //Allocates and Initializes one Object
@@ -641,7 +641,7 @@ namespace intercept {
             game_data_string & game_data_string::operator = (game_data_string &&move_);
             void free();
             ~game_data_string();
-            rv_string *raw_string;
+            r_string raw_string;
             static void* operator new(std::size_t sz_);
             static void operator delete(void* ptr_, std::size_t sz_);
         protected:
@@ -656,10 +656,8 @@ namespace intercept {
             static uintptr_t type_def;
             static uintptr_t data_type_def;
             game_data_group() {
-                type = type_def;
+                _vtable = type_def;
                 data_type = data_type_def;
-                ref_count_internal = 1;
-                ref_count_internal.set_initial(1, true);
             };
             void *group;
         };
@@ -669,10 +667,8 @@ namespace intercept {
             static uintptr_t type_def;
             static uintptr_t data_type_def;
             game_data_config() {
-                type = type_def;
+                _vtable = type_def;
                 data_type = data_type_def;
-                ref_count_internal = 1;
-                ref_count_internal.set_initial(1, true);
             };
             void *config;
         };
@@ -682,10 +678,8 @@ namespace intercept {
             static uintptr_t type_def;
             static uintptr_t data_type_def;
             game_data_control() {
-                type = type_def;
+                _vtable = type_def;
                 data_type = data_type_def;
-                ref_count_internal = 1;
-                ref_count_internal.set_initial(1, true);
             };
             void *control;
         };
@@ -695,10 +689,8 @@ namespace intercept {
             static uintptr_t type_def;
             static uintptr_t data_type_def;
             game_data_display() {
-                type = type_def;
+                _vtable = type_def;
                 data_type = data_type_def;
-                ref_count_internal = 1;
-                ref_count_internal.set_initial(1, true);
             };
             void *display;
         };
@@ -708,10 +700,8 @@ namespace intercept {
             static uintptr_t type_def;
             static uintptr_t data_type_def;
             game_data_location() {
-                type = type_def;
+                _vtable = type_def;
                 data_type = data_type_def;
-                ref_count_internal = 1;
-                ref_count_internal.set_initial(1, true);
             };
             void *location;
         };
@@ -721,10 +711,8 @@ namespace intercept {
             static uintptr_t type_def;
             static uintptr_t data_type_def;
             game_data_script() {
-                type = type_def;
+                _vtable = type_def;
                 data_type = data_type_def;
-                ref_count_internal = 1;
-                ref_count_internal.set_initial(1, true);
             };
             void *script;
         };
@@ -734,10 +722,8 @@ namespace intercept {
             static uintptr_t type_def;
             static uintptr_t data_type_def;
             game_data_side() {
-                type = type_def;
+                _vtable = type_def;
                 data_type = data_type_def;
-                ref_count_internal = 1;
-                ref_count_internal.set_initial(1, true);
             };
             void *side;
         };
@@ -747,10 +733,8 @@ namespace intercept {
             static uintptr_t type_def;
             static uintptr_t data_type_def;
             game_data_rv_text() {
-                type = type_def;
+                _vtable = type_def;
                 data_type = data_type_def;
-                ref_count_internal = 1;
-                ref_count_internal.set_initial(1, true);
             };
             void *rv_text;
         };
@@ -760,10 +744,8 @@ namespace intercept {
             static uintptr_t type_def;
             static uintptr_t data_type_def;
             game_data_team() {
-                type = type_def;
+                _vtable = type_def;
                 data_type = data_type_def;
-                ref_count_internal = 1;
-                ref_count_internal.set_initial(1, true);
             };
             void *team;
         };
@@ -773,10 +755,8 @@ namespace intercept {
             static uintptr_t type_def;
             static uintptr_t data_type_def;
             game_data_rv_namespace() {
-                type = type_def;
+                _vtable = type_def;
                 data_type = data_type_def;
-                ref_count_internal = 1;
-                ref_count_internal.set_initial(1, true);
             };
             void *rv_namespace;
         };
@@ -786,10 +766,8 @@ namespace intercept {
             static uintptr_t type_def;
             static uintptr_t data_type_def;
             game_data_code() {
-                type = type_def;
+                _vtable = type_def;
                 data_type = data_type_def;
-                ref_count_internal = 1;
-                ref_count_internal.set_initial(1, true);
             };
             rv_string *code_string;
             uintptr_t instruction_array;
@@ -803,10 +781,8 @@ namespace intercept {
             static uintptr_t type_def;
             static uintptr_t data_type_def;
             game_data_object() {
-                type = type_def;
+                _vtable = type_def;
                 data_type = data_type_def;
-                ref_count_internal = 1;
-                ref_count_internal.set_initial(1, true);
             };
             void *object;
         };

--- a/src/client/headers/shared/types.hpp
+++ b/src/client/headers/shared/types.hpp
@@ -64,15 +64,30 @@ namespace intercept {
             };
         public:
             static void deallocate(Type* _Ptr, size_t _unused = 0); //#TODO if its unused why not just remove it?!
+            //This only allocates the memory! This will not be initialized to 0 and the allocated object will not have it's constructor called! 
+            //use the create* Methods instead
             static Type* allocate(size_t _count);
 
             //Allocates and Initializes one Object
             template<class... _Types>
             static Type* createSingle(_Types&&... _Args) {
                 auto ptr = allocate(1);
-                new (ptr) Type(std::forward<_Types>(_Args)...);
+                ::new (ptr) Type(std::forward<_Types>(_Args)...);
+                //Have to do a little more unfancy stuff for people that want to overload the new operator
                 return ptr;
             }
+
+            //Allocates and initializes array of Elements using the default constructor.
+            static Type* createArray(size_t _count) {
+                auto ptr = allocate(_count);
+
+                for (size_t i = 0; i < _count; ++i) {
+                    ::new (ptr + i) Type();
+                }
+                
+                return ptr;
+            }
+
 
             //#TODO implement game_data_pool and string pool here
         };
@@ -282,7 +297,7 @@ namespace intercept {
             }
 
             bool compare_case_sensitive(const char *other) {
-                _stricmp(*this, other);
+                return _stricmp(*this, other) == 0;
             }
 
             size_t find(char ch,size_t start =0) const {

--- a/src/client/headers/shared/types.hpp
+++ b/src/client/headers/shared/types.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include <stdio.h>
 #include <set>
+#include <array>
 #include <mutex>
 #include <thread>
 #include <atomic>
@@ -15,8 +16,50 @@ namespace intercept {
 
         typedef std::set<std::string> value_types;
         typedef uintptr_t value_type;
-
-
+        class rv_pool_allocator;
+        namespace __internal
+        {
+            enum class GameDataType {
+                SCALAR,
+                BOOL,
+                ARRAY,
+                STRING,
+                NOTHING,
+                ANY,
+                NAMESPACE,
+                NaN,
+                IF,
+                WHILE,
+                FOR,
+                SWITCH,
+                EXCEPTION,
+                WITH,
+                CODE,
+                OBJECT,
+                SIDE,
+                GROUP,
+                TEXT,
+                SCRIPT,
+                TARGET,
+                JCLASS,
+                CONFIG,
+                DISPLAY,
+                CONTROL,
+                NetObject,
+                SUBGROUP,
+                TEAM_MEMBER,
+                TASK,
+                DIARY_RECORD,
+                LOCATION,
+                end
+            };
+            struct allocatorInfo {
+                uintptr_t genericAllocBase;
+                uintptr_t poolFuncAlloc;
+                uintptr_t poolFuncDealloc;
+                std::array<rv_pool_allocator*, static_cast<size_t>(GameDataType::end)> _poolAllocs;
+            };
+        }
 
 
         
@@ -91,7 +134,6 @@ namespace intercept {
 
             //#TODO implement game_data_pool and string pool here
         };
-
 
         class refcount_base {
         public:
@@ -349,6 +391,17 @@ namespace intercept {
 
 
 
+        class rv_pool_allocator {
+            char pad_0x0000[0x24]; //0x0000
+        public:
+            const r_string _allocName;
+            void* allocate(size_t count);
+            void deallocate(void* data);
+
+        };
+
+
+
         class rv_string {
         public:
             rv_string();
@@ -529,6 +582,7 @@ namespace intercept {
         public:
             static uintptr_t type_def;
             static uintptr_t data_type_def;
+            static rv_pool_allocator* pool_alloc_base;
             game_data_number();
             game_data_number(float val_);
             game_data_number(const game_data_number &copy_);
@@ -546,6 +600,7 @@ namespace intercept {
         public:
             static uintptr_t type_def;
             static uintptr_t data_type_def;
+            static rv_pool_allocator* pool_alloc_base;
             game_data_bool();
             game_data_bool(bool val_);
             game_data_bool(const game_data_bool &copy_);
@@ -640,6 +695,7 @@ namespace intercept {
         public:
             static uintptr_t type_def;
             static uintptr_t data_type_def;
+            static rv_pool_allocator* pool_alloc_base;
             game_data_array();
             game_data_array(size_t size_);
             game_data_array(const std::vector<game_value> &init_);
@@ -663,6 +719,7 @@ namespace intercept {
         public:
             static uintptr_t type_def;
             static uintptr_t data_type_def;
+            static rv_pool_allocator* pool_alloc_base;
             game_data_string();
             game_data_string(const std::string &str_);
             game_data_string(const game_data_string &copy_);

--- a/src/client/intercept/client/client.cpp
+++ b/src/client/intercept/client/client.cpp
@@ -19,17 +19,21 @@ namespace intercept {
             uintptr_t data_type_def;
 
             host::functions.get_type_structure("ARRAY", type_def, data_type_def);
+            auto allocator_info = host::functions.get_engine_allocator();
             game_data_array::type_def = type_def;
             game_data_array::data_type_def = data_type_def;
+            game_data_array::pool_alloc_base = allocator_info->_poolAllocs[static_cast<size_t>(types::__internal::GameDataType::ARRAY)];
 
 
             host::functions.get_type_structure("SCALAR", type_def, data_type_def);
             game_data_number::type_def = type_def;
             game_data_number::data_type_def = data_type_def;
+            game_data_number::pool_alloc_base = allocator_info->_poolAllocs[static_cast<size_t>(types::__internal::GameDataType::SCALAR)];
 
             host::functions.get_type_structure("STRING", type_def, data_type_def);
             game_data_string::type_def = type_def;
             game_data_string::data_type_def = data_type_def;
+            game_data_string::pool_alloc_base = allocator_info->_poolAllocs[static_cast<size_t>(types::__internal::GameDataType::STRING)];
 
             host::functions.get_type_structure("OBJECT", type_def, data_type_def);
             game_data_object::type_def = type_def;
@@ -38,6 +42,7 @@ namespace intercept {
             host::functions.get_type_structure("BOOL", type_def, data_type_def);
             game_data_bool::type_def = type_def;
             game_data_bool::data_type_def = data_type_def;
+            game_data_bool::pool_alloc_base = allocator_info->_poolAllocs[static_cast<size_t>(types::__internal::GameDataType::BOOL)];
 
             
             host::functions.get_type_structure("CODE", type_def, data_type_def);

--- a/src/client/intercept/client/client.cpp
+++ b/src/client/intercept/client/client.cpp
@@ -114,7 +114,7 @@ namespace intercept {
                 _locked = true;
             }
         }
-
+            
         host::mem_watcher::mem_watcher() {
         }
 
@@ -122,6 +122,7 @@ namespace intercept {
         }
 
         void host::mem_watcher::clean() {
+            /*
             auto data = _watch_data.begin();
             while (data != _watch_data.end()) {
                 if (data->rv_data.data->ref_count_internal <= 1) {
@@ -132,15 +133,19 @@ namespace intercept {
                     data++;
                 }
             }
+            */
         }
 
         void host::mem_watcher::add_watch(game_value & data_) {
+            /*
             _add(data_);
             clean();
+            */
         }
 
         void host::mem_watcher::_add(game_value & data_)
         {
+            /*
             if (data_.rv_data.data) {
                 if (data_.type() == game_data_array::type_def) {
                     for (uint32_t i = 0; i < data_.length(); ++i) {
@@ -153,6 +158,9 @@ namespace intercept {
                     _watch_data.push_back(data_);
                 }
             }
+            */
         }
+       
+
 }
 }

--- a/src/client/intercept/client/sqf/intersects.cpp
+++ b/src/client/intercept/client/sqf/intersects.cpp
@@ -78,7 +78,7 @@ namespace intercept {
             });
             game_value intersects_value = host::functions.invoke_raw_unary(client::__sqf::unary__lineintersectswith__array__ret__array, array_input);
 
-            game_data_array* intersects = ((game_data_array *)intersects_value.rv_data.data);
+            game_data_array* intersects = ((game_data_array *)intersects_value.rv_data.data.getRef());
 
             std::vector<object> output;
             for (uint32_t i = 0; i < intersects->length; ++i) {
@@ -98,7 +98,7 @@ namespace intercept {
             });
             game_value intersects_value = host::functions.invoke_raw_unary(client::__sqf::unary__lineintersectswith__array__ret__array, array_input);
 
-            game_data_array* intersects = ((game_data_array *)intersects_value.rv_data.data);
+            game_data_array* intersects = ((game_data_array *)intersects_value.rv_data.data.getRef());
 
             std::vector<object> output;
             for (uint32_t i = 0; i < intersects->length; ++i) {
@@ -118,7 +118,7 @@ namespace intercept {
             });
             game_value intersects_value = host::functions.invoke_raw_unary(client::__sqf::unary__lineintersectswith__array__ret__array, array_input);
 
-            game_data_array* intersects = ((game_data_array *)intersects_value.rv_data.data);
+            game_data_array* intersects = ((game_data_array *)intersects_value.rv_data.data.getRef());
 
             std::vector<object> output;
             for (uint32_t i = 0; i < intersects->length; ++i) {
@@ -185,7 +185,7 @@ namespace intercept {
             });
 
             game_value intersects_value = host::functions.invoke_raw_unary(client::__sqf::unary__lineintersectsobjs__array__ret__array, array_input);
-            game_data_array* intersects = ((game_data_array *)intersects_value.rv_data.data);
+            game_data_array* intersects = ((game_data_array *)intersects_value.rv_data.data.getRef());
 
             std::vector<object> output;
             for (uint32_t i = 0; i < intersects->length; ++i) {

--- a/src/client/intercept/client/sqf/uncategorized.cpp
+++ b/src/client/intercept/client/sqf/uncategorized.cpp
@@ -514,7 +514,7 @@ void draw_line_3d(const vector3 & pos1_, const vector3 & pos2_, const rv_color &
 
         vector2 world_to_screen(const vector3 & pos_agl_, bool & in_screen_) {
             rv_game_value result = host::functions.invoke_raw_unary(client::__sqf::unary__worldtoscreen__array__ret__array, pos_agl_);
-            if (((game_data_array *)result.data)->length == 2)
+            if (((game_data_array *)result.data.getRef())->length == 2)
                 in_screen_ = true;
             else
                 in_screen_ = false;
@@ -9148,7 +9148,7 @@ void draw_line_3d(const vector3 & pos1_, const vector3 & pos2_, const rv_color &
 
             std::vector<rv_forces_rtd> wings_forces;
             for (uint32_t i = 0; i < ret.length(); ++i) {
-                wings_forces.push_back(rv_forces_rtd({ ret[i][0], ret[i][1], ret[i][2] }));
+                wings_forces.push_back(rv_forces_rtd{ ret[i][0], ret[i][1], ret[i][2] });
             }
 
             return wings_forces;

--- a/src/client/intercept/client/sqf/uncategorized.cpp
+++ b/src/client/intercept/client/sqf/uncategorized.cpp
@@ -390,7 +390,7 @@ void set_variable(const rv_namespace & namespace_, const std::string & var_name_
 {
     game_value args = std::vector<game_value>{ namespace_, std::vector<game_value>{ var_name_, value_ } };
     host::memory_watcher.add_watch(args);
-    host::functions.invoke_raw_binary(client::__sqf::binary__call__any__code__ret__any, args, sqf::get_variable(namespace_, "intercept_fnc_setVariableNamespace"));
+    host::functions.invoke_raw_binary(client::__sqf::binary__call__any__code__ret__any, args, sqf::get_variable(sqf::mission_namespace(), "intercept_fnc_setVariableNamespace"));
 }
 
 void draw_line_3d(const vector3 & pos1_, const vector3 & pos2_, const rv_color & color_) {

--- a/src/client/intercept/shared/client_types.cpp
+++ b/src/client/intercept/shared/client_types.cpp
@@ -46,18 +46,19 @@ namespace intercept {
         }
 
         bool internal_object::operator<(const internal_object& compare_) const {
-            return ((game_data_object *)rv_data.data)->object < ((game_data_object *)compare_.rv_data.data)->object;
+            return ((game_data_object *)rv_data.data.getRef())->object < ((game_data_object *)compare_.rv_data.data.getRef())->object;
         }
 
         bool internal_object::operator>(const internal_object& compare_) const {
-            return ((game_data_object *)rv_data.data)->object > ((game_data_object *)compare_.rv_data.data)->object;
+            return ((game_data_object *)rv_data.data.getRef())->object > ((game_data_object *)compare_.rv_data.data.getRef())->object;
         }
 
         bool internal_object::is_null()
         {
+            //#TODO pointer games are not allowed anymore!
             if (!rv_data.data)
                 return true;
-            uintptr_t data = (uintptr_t)(rv_data.data);
+            uintptr_t data = (uintptr_t)(rv_data.data.getRef());
             uintptr_t data_1 = data + 12;
             uintptr_t data_2 = *(uintptr_t *)data_1;
             if (data_2) {

--- a/src/client/intercept/shared/types.cpp
+++ b/src/client/intercept/shared/types.cpp
@@ -743,9 +743,9 @@ namespace intercept {
             // deallocate object at _Ptr
             auto allocatorBase = GET_ENGINE_ALLOCATOR;
             MemTableFunctions* alloc = (MemTableFunctions*) allocatorBase->genericAllocBase;
-            std::stringstream stream;
-            stream << "deallocate " << "x * " << typeid(Type).name() << "@" << std::hex << (int)_Ptr << "\n";
-            OutputDebugStringA(stream.str().c_str());
+            //std::stringstream stream;
+            //stream << "deallocate " << "x * " << typeid(Type).name() << "@" << std::hex << (int)_Ptr << "\n";
+            //OutputDebugStringA(stream.str().c_str());
             alloc->Delete(_Ptr);
         }
 
@@ -756,9 +756,9 @@ namespace intercept {
             //uintptr_t allocatorBase = GET_ENGINE_ALLOCATOR;    
             MemTableFunctions* alloc = (MemTableFunctions*) allocatorBase->genericAllocBase;
             Type* newData = reinterpret_cast<Type*>(alloc->New(sizeof(Type)*_count));
-            std::stringstream stream;
-            stream << "allocate " << _count << " * " << typeid(Type).name() << "@" << std::hex << (int) newData << "\n";
-            OutputDebugStringA(stream.str().c_str());
+            //std::stringstream stream;
+            //stream << "allocate " << _count << " * " << typeid(Type).name() << "@" << std::hex << (int) newData << "\n";
+            //OutputDebugStringA(stream.str().c_str());
             return newData;
         }
 

--- a/src/client/intercept/shared/types.cpp
+++ b/src/client/intercept/shared/types.cpp
@@ -105,54 +105,46 @@ namespace intercept {
         }
 
         game_data_number::game_data_number() {
-            type = type_def;
+            _vtable = type_def;
             data_type = data_type_def;
-            ref_count_internal = 1;
-            ref_count_internal.set_initial(1, true);
             number = 0.0f;
         }
 
         game_data_number::game_data_number(float val_)
         {
-            type = type_def;
+            _vtable = type_def;
             data_type = data_type_def;
-            ref_count_internal = 1;
-            ref_count_internal.set_initial(1, true);
             number = val_;
         }
 
         game_data_number::game_data_number(const game_data_number & copy_)
         {
-            type = type_def;
+            _vtable = type_def;
             data_type = data_type_def;
-            ref_count_internal = 1;
-            ref_count_internal.set_initial(1, true);
             number = copy_.number;
         }
 
         game_data_number::game_data_number(game_data_number && move_)
         {
-            type = type_def;
+            _vtable = type_def;
             data_type = data_type_def;
-            ref_count_internal = move_.ref_count_internal;
+            _refcount = move_._refcount;
             number = move_.number;
         }
 
         game_data_number & game_data_number::operator=(const game_data_number & copy_)
         {
-            type = type_def;
+            _vtable = type_def;
             data_type = data_type_def;
-            ref_count_internal = 1;
-            ref_count_internal.set_initial(1, true);
             number = copy_.number;
             return *this;
         }
 
         game_data_number & game_data_number::operator=(game_data_number && move_)
         {
-            type = type_def;
+            _vtable = type_def;
             data_type = data_type_def;
-            ref_count_internal = move_.ref_count_internal;
+            _refcount = move_._refcount;
             number = move_.number;
             return *this;
         }
@@ -168,54 +160,46 @@ namespace intercept {
         }
 
         game_data_bool::game_data_bool() {
-            type = type_def;
+            _vtable = type_def;
             data_type = data_type_def;
-            ref_count_internal = 1;
-            ref_count_internal.set_initial(1, true);
             val = false;
         }
 
         game_data_bool::game_data_bool(bool val_)
         {
-            type = type_def;
+            _vtable = type_def;
             data_type = data_type_def;
-            ref_count_internal = 1;
-            ref_count_internal.set_initial(1, true);
             val = val_;
         }
 
         game_data_bool::game_data_bool(const game_data_bool & copy_)
         {
-            type = type_def;
+            _vtable = type_def;
             data_type = data_type_def;
-            ref_count_internal = 1;
-            ref_count_internal.set_initial(1, true);
             val = copy_.val;
         }
 
         game_data_bool::game_data_bool(game_data_bool && move_)
         {
-            type = type_def;
+            _vtable = type_def;
             data_type = data_type_def;
-            ref_count_internal = move_.ref_count_internal;
+            _refcount = move_._refcount;
             val = move_.val;
         }
 
         game_data_bool & game_data_bool::operator=(const game_data_bool & copy_)
         {
-            type = type_def;
+            _vtable = type_def;
             data_type = data_type_def;
-            ref_count_internal = 1;
-            ref_count_internal.set_initial(1, true);
             val = copy_.val;
             return *this;
         }
 
         game_data_bool & game_data_bool::operator=(game_data_bool && move_)
         {
-            type = type_def;
+            _vtable = type_def;
             data_type = data_type_def;
-            ref_count_internal = move_.ref_count_internal;
+            _refcount = move_._refcount;
             val = move_.val;
             return *this;
         }
@@ -231,82 +215,60 @@ namespace intercept {
         }
 
         game_data_string::game_data_string() {
-            type = type_def;
+            _vtable = type_def;
             data_type = data_type_def;
-            ref_count_internal = 1;
-            ref_count_internal.set_initial(1, true);
-            raw_string = allocate_string(128);
-            raw_string->length = 128;
-            raw_string->ref_count_internal = 1;
         }
 
         game_data_string::game_data_string(const std::string &str_)
         {
-            type = type_def;
+            _vtable = type_def;
             data_type = data_type_def;
-            ref_count_internal = 1;
-            ref_count_internal.set_initial(1, true);
-             //#TODO replace by correct implementation
-            auto str = r_string::create(str_.c_str(), str_.length() + 1);
-            raw_string = (rv_string *) str;
+            raw_string = r_string(str_.c_str(),str_.length());
            /* raw_string = allocate_string(str_.length() + 1);
             memcpy(&raw_string->char_string, str_.c_str(), str_.length() + 1);
             raw_string->length = str_.length() + 1;
             
 
             */
-            raw_string->ref_count_internal = 1;
 
         }
 
         game_data_string::game_data_string(const game_data_string & copy_)
         {
-            type = type_def;
+            _vtable = type_def;
             data_type = data_type_def;
-            ref_count_internal = 1;
-            ref_count_internal.set_initial(1, true);
-            raw_string = allocate_string(copy_.raw_string->length);
-            memcpy(&raw_string->char_string, &copy_.raw_string->char_string, copy_.raw_string->length);
-            raw_string->length = copy_.raw_string->length;
-            raw_string->ref_count_internal = 1;
+            raw_string = copy_.raw_string;
         }
 
         game_data_string::game_data_string(game_data_string && move_)
         {
-            type = type_def;
+            _vtable = type_def;
             data_type = data_type_def;
-            ref_count_internal = move_.ref_count_internal;
-            free_string(raw_string);
+            _refcount = move_._refcount;
             raw_string = move_.raw_string;
             move_.raw_string = nullptr;
         }
 
         game_data_string & game_data_string::operator=(const game_data_string & copy_)
         {
-            type = type_def;
+            _vtable = type_def;
             data_type = data_type_def;
-            ref_count_internal.set_initial(1, true);
-            raw_string = allocate_string(copy_.raw_string->length);
-            memcpy(&raw_string->char_string, &copy_.raw_string->char_string, copy_.raw_string->length);
-            raw_string->length = copy_.raw_string->length;
-            raw_string->ref_count_internal = 1;
+            raw_string = copy_.raw_string;
             return *this;
         }
 
         game_data_string & game_data_string::operator=(game_data_string && move_)
         {
-            type = type_def;
+            _vtable = type_def;
             data_type = data_type_def;
-            ref_count_internal = move_.ref_count_internal;
-            free_string(raw_string);
+            _refcount = move_._refcount;
             raw_string = move_.raw_string;
             move_.raw_string = nullptr;
             return *this;
         }
 
         void game_data_string::free() {
-            if (raw_string)
-                free_string(raw_string);
+            //#TODO dealloc?
         }
 
         game_data_string::~game_data_string()
@@ -325,30 +287,24 @@ namespace intercept {
         }
 
         game_data_array::game_data_array() {
-            type = type_def;
+            _vtable = type_def;
             data_type = data_type_def;
-            ref_count_internal = 1;
-            ref_count_internal.set_initial(1, true);
             length = 0;
             max_size = 0;
             data = nullptr;
         }
 
         game_data_array::game_data_array(size_t size_) {
-            type = type_def;
+            _vtable = type_def;
             data_type = data_type_def;
-            ref_count_internal = 1;
-            ref_count_internal.set_initial(1, true);
             data = _array_pool.acquire(size_);
             length = size_;
             max_size = size_;
         }
 
         game_data_array::game_data_array(const std::vector<game_value> &init_) {
-            type = type_def;
+            _vtable = type_def;
             data_type = data_type_def;
-            ref_count_internal = 1;
-            ref_count_internal.set_initial(1, true);
             data = _array_pool.acquire(init_.size());
             length = init_.size();
             max_size = init_.size();
@@ -359,10 +315,8 @@ namespace intercept {
         }
 
         game_data_array::game_data_array(const game_data_array & copy_) {
-            type = type_def;
+            _vtable = type_def;
             data_type = data_type_def;
-            ref_count_internal = 1;
-            ref_count_internal.set_initial(1, true);
             length = copy_.length;
             max_size = copy_.max_size;
             data = _array_pool.acquire(length);
@@ -371,10 +325,8 @@ namespace intercept {
         }
 
         game_data_array::game_data_array(game_data_array && move_) {
-            type = type_def;
+            _vtable = type_def;
             data_type = data_type_def;
-            ref_count_internal = 1;
-            ref_count_internal.set_initial(1, true);
             if (data)
                 _array_pool.release(data);
             data = move_.data;
@@ -384,10 +336,8 @@ namespace intercept {
         }
 
         game_data_array & game_data_array::operator = (const game_data_array &copy_) {
-            type = type_def;
+            _vtable = type_def;
             data_type = data_type_def;
-            ref_count_internal = 1;
-            ref_count_internal.set_initial(1, true);
             length = copy_.length;
             data = _array_pool.acquire(length);
             for (size_t i = 0; i < length; ++i)
@@ -434,7 +384,6 @@ namespace intercept {
             rv_data.__vptr = copy_.rv_data.__vptr;
             if (copy_.rv_data.data) {
                 rv_data.data = copy_.rv_data.data;
-                rv_data.data->ref_count_internal++;
             }
         }
 
@@ -451,9 +400,7 @@ namespace intercept {
         game_value::game_value(const rv_game_value &internal_)
         {
             rv_data.__vptr = internal_.__vptr;
-            rv_data.data = (game_data *)internal_.data;
-            if(rv_data.data)
-                rv_data.data->ref_count_internal++;
+            rv_data.data = internal_.data;
         }
 
         game_value::game_value(float val_)
@@ -492,11 +439,8 @@ namespace intercept {
         }
         game_value::game_value(const internal_object &internal_)
         {
-
-            rv_data = internal_.rv_data;
             rv_data.__vptr = internal_.rv_data.__vptr;
-            if (rv_data.data)
-                rv_data.data->ref_count_internal++;
+            rv_data = internal_.rv_data;
         }
         game_value::~game_value() {
             _free();
@@ -504,22 +448,25 @@ namespace intercept {
 
         void game_value::_free()
         {
+              //#TODO handle deallocation?
+
+            /*
             // Ghetto superstar...
             if (rv_data.data) {
                 rv_data.data->ref_count_internal--;
                 if (rv_data.data->ref_count_internal < rv_data.data->ref_count_internal.get_initial()) {
                     if (rv_data.data->ref_count_internal.is_intercept()) {
                         rv_data.data->ref_count_internal.clear_initial(); // make sure we clear out the initial value, so it goes back to a pure 32 bit int.
-                        if (rv_data.data && rv_data.data->type == game_data_number::type_def)
+                        if (rv_data.data && rv_data.data->_vtable == game_data_number::type_def)
                             delete (game_data_number *)rv_data.data;
 
-                        else if (rv_data.data && rv_data.data->type == game_data_string::type_def)
+                        else if (rv_data.data && rv_data.data->_vtable == game_data_string::type_def)
                             delete (game_data_string *)rv_data.data;
 
-                        else if (rv_data.data && rv_data.data->type == game_data_array::type_def)
+                        else if (rv_data.data && rv_data.data->_vtable == game_data_array::type_def)
                             delete (game_data_array *)rv_data.data;
 
-                        else if (rv_data.data && rv_data.data->type == game_data_bool::type_def)
+                        else if (rv_data.data && rv_data.data->_vtable == game_data_bool::type_def)
                             delete (game_data_bool *)rv_data.data;
 
                         else if (rv_data.data)
@@ -532,6 +479,10 @@ namespace intercept {
                     }
                 }
             }
+            */
+
+
+
         }
 
         game_value & game_value::operator = (const game_value &copy_) {
@@ -611,8 +562,6 @@ namespace intercept {
                 _free();
             rv_data.data = internal_.rv_data.data;
             rv_data.__vptr = internal_.rv_data.__vptr;
-            if(rv_data.data)
-                rv_data.data->ref_count_internal++;
             return *this;
         }
 
@@ -622,35 +571,33 @@ namespace intercept {
                 _free();
             rv_data.data = internal_.data;
             rv_data.__vptr = internal_.__vptr;
-            if (rv_data.data)
-                rv_data.data->ref_count_internal++;
             return *this;
         }
 
         game_value::operator int()
         {
-            if (rv_data.data && rv_data.data->type == game_data_number::type_def)
-                return static_cast<int>(((game_data_number *)rv_data.data)->number);
+            if (rv_data.data && rv_data.data->_vtable == game_data_number::type_def)
+                return static_cast<int>(static_cast<game_data_number *>(rv_data.data.getRef())->number);
             return 0;
         }
 
         game_value::operator float()
         {
-            if (rv_data.data && rv_data.data->type == game_data_number::type_def)
-                return ((game_data_number *)rv_data.data)->number;
+            if (rv_data.data && rv_data.data->_vtable == game_data_number::type_def)
+                return ((game_data_number *)rv_data.data.getRef())->number;
             return 0.0f;
         }
 
         game_value::operator bool()
         {
-            if (rv_data.data && rv_data.data->type == game_data_bool::type_def)
-                return ((game_data_bool *)rv_data.data)->val;
+            if (rv_data.data && rv_data.data->_vtable == game_data_bool::type_def)
+                return ((game_data_bool *)rv_data.data.getRef())->val;
             return false;
         }
 
-        game_value::operator rv_string &()
+        game_value::operator r_string ()
         {
-            return *((game_data_string *)rv_data.data)->raw_string;
+            return ((game_data_string *)rv_data.data.getRef())->raw_string;
         }
 
         game_value::operator rv_game_value *()
@@ -660,101 +607,101 @@ namespace intercept {
 
         game_value::operator vector3()
         {
-            if (((game_data_array *)rv_data.data)->length == 3)
+            if (((game_data_array *)rv_data.data.getRef())->length == 3)
                 return vector3(
-                    ((game_data_array *)rv_data.data)->data[0],
-                    ((game_data_array *)rv_data.data)->data[1],
-                    ((game_data_array *)rv_data.data)->data[2]
+                    ((game_data_array *)rv_data.data.getRef())->data[0],
+                    ((game_data_array *)rv_data.data.getRef())->data[1],
+                    ((game_data_array *)rv_data.data.getRef())->data[2]
                     );
             return vector3();
         }
 
         game_value::operator vector2()
         {
-            if(((game_data_array *)rv_data.data)->length == 2)
+            if(((game_data_array *)rv_data.data.getRef())->length == 2)
                 return vector2(
-                    ((game_data_array *)rv_data.data)->data[0],
-                    ((game_data_array *)rv_data.data)->data[1]
+                    ((game_data_array *)rv_data.data.getRef())->data[0],
+                    ((game_data_array *)rv_data.data.getRef())->data[1]
                     );
             return vector2();
         }
 
         game_value::operator int() const
         {
-            if (rv_data.data && rv_data.data->type == game_data_number::type_def)
-                return static_cast<int>(((game_data_number *)rv_data.data)->number);
+            if (rv_data.data && rv_data.data->_vtable == game_data_number::type_def)
+                return static_cast<int>(((game_data_number *)rv_data.data.getRef())->number);
             return 0;
         }
 
         game_value::operator float() const
         {
-            if (rv_data.data && rv_data.data->type == game_data_number::type_def)
-                return ((game_data_number *)rv_data.data)->number;
+            if (rv_data.data && rv_data.data->_vtable == game_data_number::type_def)
+                return ((game_data_number *)rv_data.data.getRef())->number;
             return 0.0f;
         }
 
         game_value::operator bool() const
         {
-            if (rv_data.data && rv_data.data->type == game_data_bool::type_def)
-                return ((game_data_bool *)rv_data.data)->val;
+            if (rv_data.data && rv_data.data->_vtable == game_data_bool::type_def)
+                return ((game_data_bool *)rv_data.data.getRef())->val;
             return false;
         }
 
-        game_value::operator rv_string &() const
+        game_value::operator r_string () const
         {
-            return *((game_data_string *)rv_data.data)->raw_string;
+            return ((game_data_string *)rv_data.data.getRef())->raw_string;
         }
 
         game_value::operator vector3() const
         {
             return vector3(
-                ((game_data_array *)rv_data.data)->data[0],
-                ((game_data_array *)rv_data.data)->data[1],
-                ((game_data_array *)rv_data.data)->data[2]
+                ((game_data_array *)rv_data.data.getRef())->data[0],
+                ((game_data_array *)rv_data.data.getRef())->data[1],
+                ((game_data_array *)rv_data.data.getRef())->data[2]
                 );
         }
 
         game_value::operator vector2() const
         {
             return vector2(
-                ((game_data_array *)rv_data.data)->data[0],
-                ((game_data_array *)rv_data.data)->data[1]
+                ((game_data_array *)rv_data.data.getRef())->data[0],
+                ((game_data_array *)rv_data.data.getRef())->data[1]
                 );
         }
 
         game_value::operator std::string() const
         {
-            if (rv_data.data && rv_data.data->type == game_data_string::type_def)
-                return std::string(&((game_data_string *)rv_data.data)->raw_string->char_string);
+            if (rv_data.data && rv_data.data->_vtable == game_data_string::type_def)
+                return std::string(((game_data_string *)rv_data.data.getRef())->raw_string);
             return std::string();
         }
 
         game_value::operator std::string()
         {
-            if (rv_data.data && rv_data.data->type == game_data_string::type_def)
-                return std::string(&((game_data_string *)rv_data.data)->raw_string->char_string);
+            if (rv_data.data && rv_data.data->_vtable == game_data_string::type_def)
+                return std::string(((game_data_string *)rv_data.data.getRef())->raw_string);
             return std::string();
         }
 
         game_value & game_value::operator [](int i_) {
-            assert(rv_data.data && rv_data.data->type == game_data_array::type_def && (uint32_t)i_ < ((game_data_array *)rv_data.data)->length);
-            return ((game_data_array *)rv_data.data)->data[i_];
+            assert(rv_data.data && rv_data.data->_vtable == game_data_array::type_def && (uint32_t)i_ < ((game_data_array *)rv_data.data.getRef())->length);
+            return ((game_data_array *)rv_data.data.getRef())->data[i_];
         }
 
         game_value game_value::operator [](int i_) const {
-            assert(rv_data.data && rv_data.data->type == game_data_array::type_def && (uint32_t)i_ < ((game_data_array *)rv_data.data)->length);
-            return ((game_data_array *)rv_data.data)->data[i_];
+            assert(rv_data.data && rv_data.data->_vtable == game_data_array::type_def && (uint32_t)i_ < ((game_data_array *)rv_data.data.getRef())->length);
+            return ((game_data_array *)rv_data.data.getRef())->data[i_];
         }
 
         uintptr_t game_value::type() const {
             if (rv_data.data)
-                return rv_data.data->type;
+                return rv_data.data->_vtable;
             return 0x0;
         }
 
         size_t game_value::length() const {
             if (type() == game_data_array::type_def)
-                return ((game_data_array *)rv_data.data)->length;
+                return ((game_data_array *)rv_data.data.getRef())->length;
             return 0;
         }
 
@@ -765,9 +712,9 @@ namespace intercept {
             return false;
         }
 
-        bool game_value::client_owned() const {
-            if (rv_data.data && rv_data.data->ref_count_internal.is_intercept())
-                return true;
+        bool game_value::client_owned() const {//#TODO what is this used for?
+            // if (rv_data.data && rv_data.data->ref_count_internal.is_intercept())
+            //     return true;
             return false;
         }
 

--- a/src/host/extensions/export.cpp
+++ b/src/host/extensions/export.cpp
@@ -87,5 +87,10 @@ namespace intercept {
         {
             invoker::get().unlock();
         }
+
+        uintptr_t get_engine_allocator() {
+            return loader::get().get_allocator();
+        }
+
     }
 }

--- a/src/host/extensions/export.cpp
+++ b/src/host/extensions/export.cpp
@@ -88,7 +88,7 @@ namespace intercept {
             invoker::get().unlock();
         }
 
-        uintptr_t get_engine_allocator() {
+        const types::__internal::allocatorInfo* get_engine_allocator() {
             return loader::get().get_allocator();
         }
 

--- a/src/host/extensions/export.hpp
+++ b/src/host/extensions/export.hpp
@@ -106,5 +106,14 @@ namespace intercept {
         void invoker_lock();
 
         void invoker_unlock();
+
+        /*!
+        @brief Get's a pointer to Arma's memory allocator
+
+        This returns a pointer to Arma's internal memory allocator for use by rv_allocator
+
+        @param value_ A pointer to the allocator
+        */
+        uintptr_t get_engine_allocator();
     }
 }

--- a/src/host/extensions/export.hpp
+++ b/src/host/extensions/export.hpp
@@ -114,6 +114,6 @@ namespace intercept {
 
         @param value_ A pointer to the allocator
         */
-        uintptr_t get_engine_allocator();
+        const types::__internal::allocatorInfo* get_engine_allocator();
     }
 }

--- a/src/host/extensions/extensions.cpp
+++ b/src/host/extensions/extensions.cpp
@@ -20,6 +20,7 @@ namespace intercept {
         functions.invoke_raw_unary = client_function_defs::invoke_raw_unary_nolock;
         functions.invoker_lock = client_function_defs::invoker_lock;
         functions.invoker_unlock = client_function_defs::invoker_unlock;
+        functions.get_engine_allocator = client_function_defs::get_engine_allocator;
         for (auto file : _searcher.active_pbo_list()) {
             size_t last_index = file.find_last_of("\\/");
             std::string path = file.substr(0, last_index);

--- a/src/host/extensions/extensions.hpp
+++ b/src/host/extensions/extensions.hpp
@@ -64,32 +64,32 @@ namespace intercept {
 
 
 #define EH(x) typedef void(__cdecl *x##_func)
-
-        EH(anim_changed)(object &unit_, rv_string &anim_name_);
-        EH(anim_done)(object &unit_, rv_string &anim_name_);
-        EH(anim_state_changed)(object &unit_, rv_string &anim_name_);
+        //#TODO might want r_string& here
+        EH(anim_changed)(object &unit_, r_string anim_name_);
+        EH(anim_done)(object &unit_, r_string anim_name_);
+        EH(anim_state_changed)(object &unit_, r_string anim_name_);
         EH(container_closed)(object &container_, object &player_);
         EH(controls_shifted)(object &vehicle_, object &new_controller_, object &old_controller_);
-        EH(dammaged)(object &unit_, rv_string &selection_name_, float damage_);
+        EH(dammaged)(object &unit_, r_string selection_name_, float damage_);
         EH(engine)(object &vehicle_, bool engine_state_);
-        EH(epe_contact)(object &object1_, object &object2_, rv_string &selection1_, rv_string &selection2_, float force_);
-        EH(epe_contact_end)(object &object1_, object &object2_, rv_string &selection1_, rv_string &selection2_, float force_);
-        EH(epe_contact_start)(object &object1_, object &object2_, rv_string &selection1_, rv_string &selection2_, float force_);
+        EH(epe_contact)(object &object1_, object &object2_, r_string selection1_, r_string selection2_, float force_);
+        EH(epe_contact_end)(object &object1_, object &object2_, r_string selection1_, r_string selection2_, float force_);
+        EH(epe_contact_start)(object &object1_, object &object2_, r_string selection1_, r_string selection2_, float force_);
         EH(explosion)(object &vehicle_, float damage_);
-        EH(fired)(object &unit_, rv_string &weapon_, rv_string &muzzle_, rv_string &mode_, rv_string &ammo_, rv_string &magazine, object &projectile_);
-        EH(fired_near)(object &unit_, object &firer_, float distance_, rv_string &weapon_, rv_string &muzzle_, rv_string &mode_, rv_string &ammo_);
+        EH(fired)(object &unit_, r_string weapon_, r_string muzzle_, r_string mode_, r_string ammo_, r_string magazine, object &projectile_);
+        EH(fired_near)(object &unit_, object &firer_, float distance_, r_string weapon_, r_string muzzle_, r_string mode_, r_string ammo_);
         EH(fuel)(object &vehicle_, bool fuel_state_);
         EH(gear)(object &vehicle_, bool gear_state_);
-        EH(get_in)(object &vehicle_, rv_string &position_, object &unit_, rv_list<int> &turret_path);
-        EH(get_out)(object &vehicle_, rv_string &position_, object &unit_, rv_list<int> &turret_path);
-        EH(handle_damage)(object &unit_, rv_string &selection_name_, float damage_, object &source_, rv_string &projectile_, int hit_part_index_);
+        EH(get_in)(object &vehicle_, r_string position_, object &unit_, rv_list<int> &turret_path);
+        EH(get_out)(object &vehicle_, r_string position_, object &unit_, rv_list<int> &turret_path);
+        EH(handle_damage)(object &unit_, r_string selection_name_, float damage_, object &source_, r_string projectile_, int hit_part_index_);
         EH(handle_heal)(object &unit_, object &healder_, bool healer_can_heal_);
         EH(handle_rating)(object &unit_, float rating_);
         EH(handle_score)(object &unit_, object &object_, float score_);
         EH(hit)(object &unit_, object &caused_by_, float damage_);
         EH(hit_part)(rv_list<hit_part_data> &data_);
         EH(init)(object &unit_);
-        EH(incoming_missile)(object &unit_, rv_string &ammo_, object &firer_);
+        EH(incoming_missile)(object &unit_, r_string ammo_, object &firer_);
         EH(inventory_closed)(object &object_, object &container_);
         EH(inventory_opened)(object &object_, object &container_);
         EH(killed)(object &unit_, object &killer_);
@@ -97,13 +97,13 @@ namespace intercept {
         EH(landed_stopped)(object &plane_, int airport_id_);
         EH(local)(object &object_, bool local_);
         EH(post_reset)();
-        EH(put)(object &unit_, object &container_, rv_string &item_);
+        EH(put)(object &unit_, object &container_, r_string item_);
         EH(respawn)(object &unit_, object &corpse_);
         EH(rope_attach)(object &object1, object &rope_, object &object2_);
         EH(rope_break)(object &object1, object &rope_, object &object2_);
         EH(seat_switched)(object &vehicle_, object &unit1_, object &unit2_);
         EH(sound_played)(object &unit_, int sound_code_);
-        EH(take)(object &unit_, object &container_, rv_string &item_);
+        EH(take)(object &unit_, object &container_, r_string item_);
         EH(task_set_as_current)(object &unit_, task &task_);
         EH(weapon_assembled)(object &unit_, object &weapon_);
         EH(weapon_disassembled)(object &unit_, object &primary_bag_, object &secondary_bag_);

--- a/src/host/invoker/eventhandlers.cpp
+++ b/src/host/invoker/eventhandlers.cpp
@@ -105,24 +105,24 @@ namespace intercept {
     }
 
     
-    EH_START(anim_changed)(static_cast<object &>(args_[0]), static_cast<rv_string &>(args_[1]))EH_END;
-    EH_START(anim_done)(static_cast<object &>(args_[0]), static_cast<rv_string &>(args_[1]))EH_END;
-    EH_START(anim_state_changed)(static_cast<object &>(args_[0]), static_cast<rv_string &>(args_[1]))EH_END;
+    EH_START(anim_changed)(static_cast<object &>(args_[0]), static_cast<r_string>(args_[1]))EH_END;
+    EH_START(anim_done)(static_cast<object &>(args_[0]), static_cast<r_string>(args_[1]))EH_END;
+    EH_START(anim_state_changed)(static_cast<object &>(args_[0]), static_cast<r_string>(args_[1]))EH_END;
     EH_START(container_closed)(static_cast<object &>(args_[0]), static_cast<object &>(args_[1]))EH_END;
     EH_START(controls_shifted)(static_cast<object &>(args_[0]), static_cast<object &>(args_[1]), static_cast<object &>(args_[2]))EH_END;
-    EH_START(dammaged)(static_cast<object &>(args_[0]), static_cast<rv_string &>(args_[1]), static_cast<float>(args_[2]))EH_END;
+    EH_START(dammaged)(static_cast<object &>(args_[0]), static_cast<r_string>(args_[1]), static_cast<float>(args_[2]))EH_END;
     EH_START(engine)(static_cast<object &>(args_[0]), static_cast<bool>(args_[1]))EH_END;
-    EH_START(epe_contact)(static_cast<object &>(args_[0]), static_cast<object &>(args_[1]), static_cast<rv_string &>(args_[2]), static_cast<rv_string &>(args_[3]), static_cast<float>(args_[4]))EH_END;
-    EH_START(epe_contact_end)(static_cast<object &>(args_[0]), static_cast<object &>(args_[1]), static_cast<rv_string &>(args_[2]), static_cast<rv_string &>(args_[3]), static_cast<float>(args_[4]))EH_END;
-    EH_START(epe_contact_start)(static_cast<object &>(args_[0]), static_cast<object &>(args_[1]), static_cast<rv_string &>(args_[2]), static_cast<rv_string &>(args_[3]), static_cast<float>(args_[4]))EH_END;
+    EH_START(epe_contact)(static_cast<object &>(args_[0]), static_cast<object &>(args_[1]), static_cast<r_string>(args_[2]), static_cast<r_string>(args_[3]), static_cast<float>(args_[4]))EH_END;
+    EH_START(epe_contact_end)(static_cast<object &>(args_[0]), static_cast<object &>(args_[1]), static_cast<r_string>(args_[2]), static_cast<r_string>(args_[3]), static_cast<float>(args_[4]))EH_END;
+    EH_START(epe_contact_start)(static_cast<object &>(args_[0]), static_cast<object &>(args_[1]), static_cast<r_string>(args_[2]), static_cast<r_string>(args_[3]), static_cast<float>(args_[4]))EH_END;
     EH_START(explosion)(static_cast<object &>(args_[0]), static_cast<float>(args_[1]))EH_END;
     
-    EH_START(fired)(static_cast<object &>(args_[0]), static_cast<rv_string &>(args_[1]), static_cast<rv_string &>(args_[2]), static_cast<rv_string &>(args_[3]), static_cast<rv_string &>(args_[4]), static_cast<rv_string &>(args_[5]), static_cast<object &>(args_[6]))EH_END;
+    EH_START(fired)(static_cast<object &>(args_[0]), static_cast<r_string>(args_[1]), static_cast<r_string>(args_[2]), static_cast<r_string>(args_[3]), static_cast<r_string>(args_[4]), static_cast<r_string>(args_[5]), static_cast<object &>(args_[6]))EH_END;
     
-    EH_START(fired_near)(static_cast<object &>(args_[0]), static_cast<object &>(args_[1]), static_cast<float>(args_[2]), static_cast<rv_string &>(args_[3]), static_cast<rv_string &>(args_[4]), static_cast<rv_string &>(args_[5]), static_cast<rv_string &>(args_[6]))EH_END;
+    EH_START(fired_near)(static_cast<object &>(args_[0]), static_cast<object &>(args_[1]), static_cast<float>(args_[2]), static_cast<r_string>(args_[3]), static_cast<r_string>(args_[4]), static_cast<r_string>(args_[5]), static_cast<r_string>(args_[6]))EH_END;
     EH_START(fuel)(static_cast<object &>(args_[0]), static_cast<bool>(args_[1]))EH_END;
     EH_START(gear)(static_cast<object &>(args_[0]), static_cast<bool>(args_[1]))EH_END;
-    //EH_START(get_in)(static_cast<object &>(args_[0]), static_cast<rv_string &>(args_[1]), static_cast<object &>(args_[2]), std::vector<int> turret_path)EH_END;
+    //EH_START(get_in)(static_cast<object &>(args_[0]), static_cast<r_string>(args_[1]), static_cast<object &>(args_[2]), std::vector<int> turret_path)EH_END;
 
     void eventhandlers::get_in(const std::string & name_, game_value & args_)
     {
@@ -132,7 +132,7 @@ namespace intercept {
 
         for (auto module : extensions::get().modules()) {
             if (module.second.eventhandlers.get_in) {
-                module.second.eventhandlers.get_in(static_cast<object &>(args_[0]), static_cast<rv_string &>(args_[1]), static_cast<object &>(args_[2]), turret_path);
+                module.second.eventhandlers.get_in(static_cast<object &>(args_[0]), static_cast<r_string>(args_[1]), static_cast<object &>(args_[2]), turret_path);
             }
         }
     }
@@ -147,19 +147,19 @@ namespace intercept {
 
         for (auto module : extensions::get().modules()) {
             if (module.second.eventhandlers.get_out) {
-                module.second.eventhandlers.get_out(static_cast<object &>(args_[0]), static_cast<rv_string &>(args_[1]), static_cast<object &>(args_[2]), turret_path);
+                module.second.eventhandlers.get_out(static_cast<object &>(args_[0]), static_cast<r_string>(args_[1]), static_cast<object &>(args_[2]), turret_path);
             }
         }
     }
 
-    EH_START(handle_damage)(static_cast<object &>(args_[0]), static_cast<rv_string &>(args_[1]), static_cast<float>(args_[2]), static_cast<object &>(args_[3]), static_cast<rv_string &>(args_[4]), static_cast<int>(args_[5]))EH_END;
+    EH_START(handle_damage)(static_cast<object &>(args_[0]), static_cast<r_string>(args_[1]), static_cast<float>(args_[2]), static_cast<object &>(args_[3]), static_cast<r_string>(args_[4]), static_cast<int>(args_[5]))EH_END;
     EH_START(handle_heal)(static_cast<object &>(args_[0]), static_cast<object &>(args_[1]), static_cast<bool>(args_[2]))EH_END;
     EH_START(handle_rating)(static_cast<object &>(args_[0]), static_cast<float>(args_[1]))EH_END;
     EH_START(handle_score)(static_cast<object &>(args_[0]), static_cast<object &>(args_[1]), static_cast<float>(args_[2]))EH_END;
     EH_START(hit)(static_cast<object &>(args_[0]), static_cast<object &>(args_[1]), static_cast<float>(args_[2]))EH_END;
     //EH_START(hit_part)(std::vector<hit_part_data> data_)EH_END;
     EH_START(init)(static_cast<object &>(args_[0]))EH_END;
-    EH_START(incoming_missile)(static_cast<object &>(args_[0]), static_cast<rv_string &>(args_[1]), static_cast<object &>(args_[2]))EH_END;
+    EH_START(incoming_missile)(static_cast<object &>(args_[0]), static_cast<r_string>(args_[1]), static_cast<object &>(args_[2]))EH_END;
     EH_START(inventory_closed)(static_cast<object &>(args_[0]), static_cast<object &>(args_[1]))EH_END;
     EH_START(inventory_opened)(static_cast<object &>(args_[0]), static_cast<object &>(args_[1]))EH_END;
     EH_START(killed)(static_cast<object &>(args_[0]), static_cast<object &>(args_[1]))EH_END;
@@ -167,13 +167,13 @@ namespace intercept {
     EH_START(landed_stopped)(static_cast<object &>(args_[0]), static_cast<int>(args_[1]))EH_END;
     EH_START(local)(static_cast<object &>(args_[0]), static_cast<bool>(args_[1]))EH_END;
     EH_START(post_reset)()EH_END;
-    EH_START(put)(static_cast<object &>(args_[0]), static_cast<object &>(args_[1]), static_cast<rv_string &>(args_[2]))EH_END;
+    EH_START(put)(static_cast<object &>(args_[0]), static_cast<object &>(args_[1]), static_cast<r_string>(args_[2]))EH_END;
     EH_START(respawn)(static_cast<object &>(args_[0]), static_cast<object &>(args_[1]))EH_END;
     EH_START(rope_attach)(static_cast<object &>(args_[0]), static_cast<object &>(args_[1]), static_cast<object &>(args_[2]))EH_END;
     EH_START(rope_break)(static_cast<object &>(args_[0]), static_cast<object &>(args_[1]), static_cast<object &>(args_[2]))EH_END;
     EH_START(seat_switched)(static_cast<object &>(args_[0]), static_cast<object &>(args_[1]), static_cast<object &>(args_[2]))EH_END;
     EH_START(sound_played)(static_cast<object &>(args_[0]), static_cast<int>(args_[1]))EH_END;
-    EH_START(take)(static_cast<object &>(args_[0]), static_cast<object &>(args_[1]), static_cast<rv_string &>(args_[2]))EH_END;
+    EH_START(take)(static_cast<object &>(args_[0]), static_cast<object &>(args_[1]), static_cast<r_string>(args_[2]))EH_END;
     EH_START(task_set_as_current)(static_cast<object &>(args_[0]), static_cast<task &>(args_[1]))EH_END;
     EH_START(weapon_assembled)(static_cast<object &>(args_[0]), static_cast<object &>(args_[1]))EH_END;
     EH_START(weapon_disassembled)(static_cast<object &>(args_[0]), static_cast<object &>(args_[1]), static_cast<object &>(args_[2]))EH_END;

--- a/src/host/invoker/invoker.cpp
+++ b/src/host/invoker/invoker.cpp
@@ -316,6 +316,7 @@ namespace intercept {
             invoker::get().type_structures["ARRAY"] = structure;
             game_data_array::type_def = structure.first;
             game_data_array::data_type_def = structure.second;
+            game_data_array::pool_alloc_base = loader::get().get_allocator()->_poolAllocs[static_cast<size_t>(types::__internal::GameDataType::ARRAY)];
             //invoker::get()._delete_array_ptr = game_value(right_arg_);
             
         }
@@ -324,18 +325,21 @@ namespace intercept {
             invoker::get().type_structures["SCALAR"] = structure;
             game_data_number::type_def = structure.first;
             game_data_number::data_type_def = structure.second;
+            game_data_number::pool_alloc_base = loader::get().get_allocator()->_poolAllocs[static_cast<size_t>(types::__internal::GameDataType::SCALAR)];
         }
         else if (step == "bool_type") {
             invoker::get().type_map[structure.first] = "BOOL";
             invoker::get().type_structures["BOOL"] = structure;
             game_data_bool::type_def = structure.first;
             game_data_bool::data_type_def = structure.second;
+            game_data_bool::pool_alloc_base = loader::get().get_allocator()->_poolAllocs[static_cast<size_t>(types::__internal::GameDataType::BOOL)];
         }
         else if (step == "string_type") {
             invoker::get().type_map[structure.first] = "STRING";
             invoker::get().type_structures["STRING"] = structure;
             game_data_string::type_def = structure.first;
             game_data_string::data_type_def = structure.second;
+            game_data_string::pool_alloc_base = loader::get().get_allocator()->_poolAllocs[static_cast<size_t>(types::__internal::GameDataType::STRING)];
         }
         else if (step == "code_type") {
             invoker::get().type_map[structure.first] = "CODE";

--- a/src/host/invoker/invoker.cpp
+++ b/src/host/invoker/invoker.cpp
@@ -203,10 +203,6 @@ namespace intercept {
         rv_game_value ret;
         ret.__vptr = *(uintptr_t *)ret_ptr;
         ret.data = (game_data *)*(uintptr_t *)(ret_ptr + 4);
-        if (ret.data) {
-            ret.data->ref_count_internal.set_initial((uint16_t)ret.data->ref_count_internal, false);
-            ret.data->ref_count_internal = (uint16_t)ret.data->ref_count_internal - 1;
-        }
         return ret;
     }
 
@@ -225,10 +221,6 @@ namespace intercept {
         rv_game_value ret;
         ret.__vptr = *(uintptr_t *)ret_ptr;
         ret.data = (game_data *)*(uintptr_t *)(ret_ptr + 4);
-        if (ret.data) {
-            ret.data->ref_count_internal.set_initial((uint16_t)ret.data->ref_count_internal, false);
-            ret.data->ref_count_internal = (uint16_t)ret.data->ref_count_internal - 1;
-        }
         return ret;
     }
 
@@ -257,10 +249,6 @@ namespace intercept {
         rv_game_value ret;
         ret.__vptr = *(uintptr_t *)ret_ptr;
         ret.data = (game_data *)*(uintptr_t *)(ret_ptr + 4);
-        if (ret.data) {
-            ret.data->ref_count_internal.set_initial((uint16_t)ret.data->ref_count_internal, false);
-            ret.data->ref_count_internal = (uint16_t)ret.data->ref_count_internal - 1;
-        }
         return ret;
     }
 
@@ -296,7 +284,6 @@ namespace intercept {
     bool invoker::release_value(game_value &value_, bool immediate_) {
         if (!value_.client_owned()) {
             std::lock_guard<std::mutex> delete_lock(_delete_mutex);
-            value_.rv_data.data->ref_count_internal++;
             _to_delete.push(value_.rv_data.data);
             return true;
         }

--- a/src/host/loader/loader.cpp
+++ b/src/host/loader/loader.cpp
@@ -186,7 +186,7 @@ namespace intercept {
             //const rv_string* placeholder13;
         };
         struct gsOperator {
-            const  rv_string* _name;
+            r_string _name;
             uint32_t placeholder1;//0x4
             uint32_t placeholder2;//0x8 actually a pointer to empty memory
             uint32_t placeholder3;//0xC
@@ -195,18 +195,18 @@ namespace intercept {
             uint32_t placeholder6;//0x18
             uint32_t placeholder7;//0x1C
             uint32_t placeholder8;//0x20
-            uint32_t placeholder9;//0x24
-            const rv_string* _name2;//0x28 this is (tolower name)
-            int32_t placeholder10; //0x2C Small int 0-5
+            uint32_t placeholder9;//0x24  JNI function
+            r_string _name2;//0x28 this is (tolower name)
+            int32_t placeholder10; //0x2C Small int 0-5  priority
             binary_operator * _operator;//0x30
-            const rv_string* _leftType;//0x34 Description of left hand side parameter
-            const rv_string* _rightType;//0x38 Description of right hand side parameter
-            const rv_string* _description;//0x3C
-            const rv_string* _example;//0x40
-            const rv_string* placeholder11;//0x44
-            const rv_string* _version;//0x48 some version number
-            const rv_string* placeholder12;//0x4C
-            const rv_string* _category; //0x50
+            r_string _leftType;//0x34 Description of left hand side parameter
+            r_string _rightType;//0x38 Description of right hand side parameter
+            r_string _description;//0x3C
+            r_string _example;//0x40
+            r_string placeholder11;//0x44
+            r_string _version;//0x48 some version number
+            r_string placeholder12;//0x4C
+            r_string _category; //0x50
         };
 		struct gsNular {
             const rv_string* _name;
@@ -306,7 +306,7 @@ namespace intercept {
                     binary_entry new_entry;
                     new_entry.op = entry._operator;
                     new_entry.procedure_ptr_addr = (uintptr_t) &entry._operator->procedure_addr;
-                    new_entry.name = &entry._name->char_string;
+                    new_entry.name = entry._name.data();
                     LOG(INFO) << "Found binary operator: " <<
                         new_entry.op->return_type.type_str() << " " <<
                         "(" << new_entry.op->arg1_type.type_str() << ")" <<
@@ -456,6 +456,7 @@ namespace intercept {
         const char* test = getRTTIName(*reinterpret_cast<uintptr_t*>(allocatorVtablePtr));
         assert(strcmp(test, "?AVMemTableFunctions@@") == 0);
         _allocator.genericAllocBase = allocatorVtablePtr;
+        //#TODO these patternfinds can be replaced by taking the alloc function out of any Types createFunction. and the dealloc function is right next to it asm wise
         _allocator.poolFuncAlloc = findInMemoryPattern("\x56\x8B\xF1\xFF\x46\x38\x8B\x46\x04\x3B\xC6\x74\x09\x85\xC0\x74\x05\x83\xC0\xF0\x75\x26\x8B\x4E\x10\x8D\x46\x0C\x3B\xC8\x74\x0B\x85\xC9\x74\x07\x8D\x41\xF0\x85\xC0\x75\x11", "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx");
         _allocator.poolFuncDealloc = findInMemoryPattern("\x8B\x44\x24\x04\x85\xC0\x74\x09\x89\x44\x24\x04\xE9", "xxxxxxxxxxxxx");
         

--- a/src/host/loader/loader.cpp
+++ b/src/host/loader/loader.cpp
@@ -373,9 +373,8 @@ namespace intercept {
 
         uintptr_t allocatorVtablePtr = (findInMemory((char*)&stringOffset, 4) -4) ;
         const char* test = getRTTIName(*reinterpret_cast<uintptr_t*>(allocatorVtablePtr));
-        runtime_assert(strcmp(test, "") == 0);
+        assert(strcmp(test, "?AVMemTableFunctions@@") == 0);
         _allocator = allocatorVtablePtr;
-
     }
 
     const unary_map & loader::unary() const {

--- a/src/host/loader/loader.hpp
+++ b/src/host/loader/loader.hpp
@@ -214,7 +214,7 @@ namespace intercept {
         /*!
         @brief Returns the pointer to the engines allocator functions.
         */
-        uintptr_t get_allocator() const;
+        const types::__internal::allocatorInfo* get_allocator() const;
 
 
     protected:
@@ -241,9 +241,9 @@ namespace intercept {
         std::unordered_set<uint32_t> _hooked_functions;
 
         /*!
-        @brief Stores the pointer to the engines allocator functions.
+        @brief Stores the data about the engines allocators.
         */
-        uintptr_t _allocator;
+        types::__internal::allocatorInfo _allocator;
 
         bool _attached;
         bool _patched;

--- a/src/host/loader/loader.hpp
+++ b/src/host/loader/loader.hpp
@@ -211,6 +211,12 @@ namespace intercept {
         const nular_map & nular() const;
         //!@}
 
+        /*!
+        @brief Returns the pointer to the engines allocator functions.
+        */
+        uintptr_t get_allocator() const;
+
+
     protected:
         /*!
         @name Function Maps
@@ -233,6 +239,11 @@ namespace intercept {
         @brief Stores the hooked functions.
         */
         std::unordered_set<uint32_t> _hooked_functions;
+
+        /*!
+        @brief Stores the pointer to the engines allocator functions.
+        */
+        uintptr_t _allocator;
 
         bool _attached;
         bool _patched;


### PR DESCRIPTION
Adds Generic Arma Allocator for RString and Arrays.
Adds Pool Allocator for GameData types

These allocators provide direct access to the Engine Allocator. Meaning we no longer have to wait for our allocated objects to become unused. Because Arma can now deallocate our allocated objects and we can also deallocate Arma objects.

Also includes new r_string implementation that mirrors the real engine type more closely
Also provides correctish Implementation of RefCount class so we don't need to emulate refcounting ourselves anymore.