### PR TITLE
Fix pboprefix missing \rv\

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,14 +1,12 @@
+rv/*
+!rv/addons
 rv/addons/*.pbo
 rv/addons/*.bat
 rv/*.dll
 rv/carma_dll.*
 build
-rv/intercept
-rv/intercept.ilk
-rv/intercept.pdb
 !.gitkeep
 vcproj/*
 vcproj64/*
-!vcproj/.gitkeep
 .vs
 x64/*

--- a/tools/build.py
+++ b/tools/build.py
@@ -7,6 +7,7 @@ import subprocess
 ######## GLOBALS #########
 MAINPREFIX = "z"
 PREFIX = "intercept_"
+SUBPREFIX = "rv"
 ##########################
 
 def mod_time(path):
@@ -72,7 +73,7 @@ def main():
             subprocess.check_output([
                 "makepbo",
                 "-NUP",
-                "-@={}\\{}\\addons\\{}".format(MAINPREFIX,PREFIX.rstrip("_"),p),
+                "-@={}\\{}\\{}\\addons\\{}".format(MAINPREFIX,PREFIX.rstrip("_"),SUBPREFIX,p),
                 p,
                 "{}{}.pbo".format(PREFIX,p)
             ], stderr=subprocess.STDOUT)


### PR DESCRIPTION
- Title
- Add all files in `rv/` folder to .gitignore except `rv/addons/` folder - previously only Win32 build stuff, now catches everything

_Already included in v0.8.0 package._