### PR TITLE
Added extra parameters to drawIcon3D

### DIFF
--- a/src/client/headers/client/sqf/misc.hpp
+++ b/src/client/headers/client/sqf/misc.hpp
@@ -186,7 +186,7 @@ namespace intercept {
 
         //3D stuff
         void draw_line_3d(const vector3 &pos1_, const vector3 &pos2_, const rv_color &color_);
-        void draw_icon_3d(sqf_string_const_ref texture_, const rv_color &color_, const vector3 &pos_agl_, float width_, float height_, float angle_, sqf_string_const_ref text_ = "", float shadow_ = 1.0f, float text_size_ = 1.0f, sqf_string_const_ref font_ = "TahomaB");
+        void draw_icon_3d(sqf_string_const_ref texture_, const rv_color &color_, const vector3 &pos_agl_, float width_, float height_, float angle_, sqf_string_const_ref text_ = "", float shadow_ = 1.0f, float text_size_ = 1.0f, sqf_string_const_ref font_ = "TahomaB", sqf_string_const_ref text_align_ = "center", bool draw_offscreen_ = false);
 
         /* potential namespace: particles */
         void set_particle_params(const object &particle_source_, const rv_particle_array &particle_array_);

--- a/src/client/intercept/client/sqf/misc.cpp
+++ b/src/client/intercept/client/sqf/misc.cpp
@@ -486,7 +486,7 @@ namespace intercept {
             host::functions.invoke_raw_unary(__sqf::unary__drawline3d__array__ret__nothing, args);
         }
 
-        void draw_icon_3d(sqf_string_const_ref texture_, const rv_color & color_, const vector3 & pos_agl_, float width_, float height_, float angle_, sqf_string_const_ref text_, float shadow_, float text_size_, sqf_string_const_ref font_) {
+        void draw_icon_3d(sqf_string_const_ref texture_, const rv_color & color_, const vector3 & pos_agl_, float width_, float height_, float angle_, sqf_string_const_ref text_, float shadow_, float text_size_, sqf_string_const_ref font_, sqf_string_const_ref text_align_, bool draw_offscreen_) {
             game_value args({
                 texture_,
                 color_,
@@ -497,7 +497,9 @@ namespace intercept {
                 text_,
                 shadow_,
                 text_size_,
-                font_
+                font_,
+                text_align_,
+                draw_offscreen_
             });
 
             host::functions.invoke_raw_unary(__sqf::unary__drawicon3d__array__ret__nothing, args);


### PR DESCRIPTION
The existing implementation for drawIcon3D was missing the text align parameter and draw off screen parameter. This adds those 2 parameters. They are optional, and default to "center" and false respectively.