### PR TITLE
Added spawn and isEqual* Wrappers

### DIFF
--- a/src/client/headers/client/sqf/core.hpp
+++ b/src/client/headers/client/sqf/core.hpp
@@ -1,4 +1,4 @@
-﻿/*!
+/*!
 @file
 @author Verox (verox.averre@gmail.com)
 @author Nou (korewananda@gmail.com)
@@ -25,6 +25,8 @@ namespace intercept {
         //This variant is special in that it works before preInit. The one without args doesn't
         game_value call(const code &code_, game_value args_);
         game_value call(const code &code_);
+        script spawn(game_value args, const code &code_);
+
 
         bool is_nil_code(const code &code_);
         code compile(sqf_string_const_ref sqf_);
@@ -222,6 +224,19 @@ namespace intercept {
         int count_type(sqf_string_const_ref type_, const std::vector<object> &objects_);
         int count_unknown(const object &unit_, const std::vector<object> &units_);
         rv_cursor_object_params get_cursor_object_params();
+
+
+        bool is_equal_to(game_value left_, game_value right_);
+        bool is_equal_type(game_value left_, game_value right_);
+        bool is_equal_type_all(game_value value_array_, game_value type_);
+        bool is_equal_type_any(game_value value_, game_value types_array_);
+        bool is_equal_type_array(game_value left_array_, game_value right_array_);
+        bool is_equal_type_params(game_value value_, game_value template_);
+
+
+
+
+
 
     }  // namespace sqf
 }  // namespace intercept

--- a/src/client/intercept/client/sqf/core.cpp
+++ b/src/client/intercept/client/sqf/core.cpp
@@ -75,6 +75,13 @@ namespace intercept {
             return get_variable(mission_namespace(), "INTERCEPT_CALL_RETURN"sv);
         }
 
+        script spawn(game_value args, const code& code_) {
+            return host::functions.invoke_raw_binary(
+                __sqf::binary__spawn__any__code__ret__script,
+                args,
+                code_);
+        }
+
         bool is_nil_code(const code &code_) {
             return host::functions.invoke_raw_unary(
                 __sqf::unary__isnil__code_string__ret__bool,
@@ -862,6 +869,32 @@ namespace intercept {
 
             host::functions.invoke_raw_unary(__sqf::unary__removemissioneventhandler__array__ret__nothing, params);
         }
+
+        bool is_equal_to(game_value left_, game_value right_) {
+            return host::functions.invoke_raw_binary(__sqf::binary__isequalto__any__any__ret__bool, left_, right_);
+        }
+
+        bool is_equal_type(game_value left_, game_value right_) {
+            return host::functions.invoke_raw_binary(__sqf::binary__isequaltype__any__any__ret__bool, left_, right_);
+        }
+
+        bool is_equal_type_all(game_value value_array_, game_value type_) {
+            return host::functions.invoke_raw_binary(__sqf::binary__isequaltypeall__array__any__ret__bool, value_array_, type_);
+        }
+
+        bool is_equal_type_any(game_value value_, game_value types_array_) {
+            return host::functions.invoke_raw_binary(__sqf::binary__isequaltypeany__any__array__ret__bool, value_, types_array_);
+        }
+
+        bool is_equal_type_array(game_value left_array_, game_value right_array_) {
+            return host::functions.invoke_raw_binary(__sqf::binary__isequaltypearray__array__array__ret__bool, left_array_, right_array_);
+        }
+
+        bool is_equal_type_params(game_value value_, game_value template_) {
+            return host::functions.invoke_raw_binary(__sqf::binary__isequaltypeparams__any__array__ret__bool, value_, template_);
+        }
+
+
 
     }  // namespace sqf
 }  // namespace intercept

--- a/src/client/intercept/client/sqf/uncategorized.cpp
+++ b/src/client/intercept/client/sqf/uncategorized.cpp
@@ -1,4 +1,4 @@
-﻿#include "uncategorized.hpp"
+#include "uncategorized.hpp"
 #include "client/pointers.hpp"
 #include "common_helpers.hpp"
 #include "position.hpp"  //for uses of get_pos_obj. Should be removed once they are sorted
@@ -96,12 +96,6 @@ namespace intercept {
         // binary__foreachmemberteam__code__team_member__ret__nothing
         // binary__from__for__scalar__ret__for
         // binary__in__any__array__ret__bool
-        // binary__isequalto__any__any__ret__bool
-        // binary__isequaltype__any__any__ret__bool
-        // binary__isequaltypeall__array__any__ret__bool
-        // binary__isequaltypeany__any__array__ret__bool
-        // binary__isequaltypearray__array__array__ret__bool
-        // binary__isequaltypeparams__any__array__ret__bool
         // binary__joinstring__array__string__ret__string
         // binary__max__scalar_nan__scalar_nan__ret__scalar_nan
         // binary__min__scalar_nan__scalar_nan__ret__scalar_nan
@@ -116,7 +110,6 @@ namespace intercept {
         // binary__select__array__bool__ret__any
         // binary__select__array__array__ret__array
         // binary__select__string__array__ret__string
-        // binary__spawn__any__code__ret__script ------------------------------------------------------------------------
         // binary__splitstring__string__string__ret__array
         // binary__step__for__scalar__ret__for
         // binary__then__if__code__ret__any


### PR DESCRIPTION
- binary__isequalto__any__any__ret__bool
- binary__isequaltype__any__any__ret__bool
- binary__isequaltypeall__array__any__ret__bool
- binary__isequaltypeany__any__array__ret__bool
- binary__isequaltypearray__array__array__ret__bool
- binary__isequaltypeparams__any__array__ret__bool
- binary__spawn__any__code__ret__script

I decided to implement the isEqual* wrappers because they are very useful and should have no huge performance impact. All they are doing in engine side is basically comparing numbers.
We can already do isEqualTo and isEqualType using our methods. But they are clunky and in the end do the same as the in-engine solutions just more complicated.

@RZSenfo requested `spawn` and I see this being useful to easilly launch tasks you don't care about when they complete.
