### PR TITLE
Disable all spaming debug logs

### DIFF
--- a/src/host/extensions/search.cpp
+++ b/src/host/extensions/search.cpp
@@ -59,11 +59,10 @@ namespace intercept::search {
     }
 #ifdef __linux__
     std::optional<std::string> plugin_searcher::find_extension(const std::string& name) {
-        LOG(DEBUG) << "Searching for Extension: "sv << name << "\n"sv;
+        LOG(INFO) << "Searching for Extension: "sv << name << "\n"sv;
         for (auto folder : active_mod_folder_list) {
             std::string test_path = folder + "/intercept/" + name + ".so";
 
-            LOG(DEBUG) << "Mod: "sv << test_path << "\n"sv;
             std::ifstream check_file(test_path);
             if (check_file.good()) {
                 return test_path;
@@ -74,7 +73,7 @@ namespace intercept::search {
     }
 #else
     std::optional<std::wstring> plugin_searcher::find_extension(const std::wstring& name) {
-        LOG(DEBUG) << "Searching for Extension: "sv << name << "\n"sv;
+        LOG(INFO) << "Searching for Extension: "sv << name << "\n"sv;
         for (auto folder : active_mod_folder_list) {
         #if _WIN64 || __X86_64__
             std::wstring test_path = folder + L"\\intercept\\" + name + L"_x64.dll";
@@ -82,7 +81,6 @@ namespace intercept::search {
             std::wstring test_path = folder + L"\\intercept\\" + name + L".dll";
         #endif
 
-            LOG(DEBUG) << "Mod: "sv << test_path << "\n"sv;
             std::ifstream check_file(test_path);
             if (check_file.good()) {
                 return test_path;

--- a/src/host/invoker/invoker.cpp
+++ b/src/host/invoker/invoker.cpp
@@ -179,7 +179,7 @@ namespace intercept {
     }
 
     bool invoker::rv_event(const std::string& event_name_, game_value& params_) {
-        LOG(DEBUG) << "EH "sv << event_name_ << " START"sv;
+        //LOG(DEBUG) << "EH "sv << event_name_ << " START"sv;
         auto handler = _eventhandlers.find(event_name_);
         if (handler != _eventhandlers.end()) {
             bool all = false;
@@ -191,7 +191,7 @@ namespace intercept {
             _invoker_unlock eh_lock(this, all);
             //game_value params = invoke_raw_nolock(_get_variable_func, &_mission_namespace, &var_name);
             handler->second(params_);
-            LOG(DEBUG) << "EH "sv << event_name_ << " END"sv;
+            //LOG(DEBUG) << "EH "sv << event_name_ << " END"sv;
             return true;
         }
         return false;
@@ -202,7 +202,7 @@ namespace intercept {
     }
 
     bool invoker::signal(const std::string& extension_name, const std::string& signal_name, game_value args) {
-        LOG(DEBUG) << "Signal "sv << extension_name << " : " << signal_name << " START"sv;
+        //LOG(DEBUG) << "Signal "sv << extension_name << " : " << signal_name << " START"sv;
 
         auto signal_module = extensions::get().modules().find(extension_name);
         if (signal_module == extensions::get().modules().end()) {
@@ -225,7 +225,7 @@ namespace intercept {
         }
         _invoker_unlock signal_lock(this);
         signal_func(args);
-        LOG(DEBUG) << "Signal "sv << extension_name << " : " << signal_name << " END"sv;
+        //LOG(DEBUG) << "Signal "sv << extension_name << " : " << signal_name << " END"sv;
         return true;
     }
 
@@ -471,12 +471,12 @@ namespace intercept {
         _invoke_condition.wait(lock, [] {return invoker_accessible_all; });
         _invoke_mutex.lock();
 
-        LOG(DEBUG) << "Client Thread ACQUIRE EXCLUSIVE"sv;
+        //LOG(DEBUG) << "Client Thread ACQUIRE EXCLUSIVE"sv;
     }
 
     void invoker::unlock() {
         _invoke_mutex.unlock();
-        LOG(DEBUG) << "Client Thread RELEASE EXCLUSIVE"sv;
+        //LOG(DEBUG) << "Client Thread RELEASE EXCLUSIVE"sv;
         _thread_count = _thread_count - 1;
     }
 
@@ -493,10 +493,10 @@ namespace intercept {
                 std::lock_guard<std::recursive_mutex> invoke_lock(_instance->_invoke_mutex);
                 invoker_accessible = false;
                 invoker_accessible_all = false;
-                LOG(DEBUG) << "LOCKED ALL"sv;
+                //LOG(DEBUG) << "LOCKED ALL"sv;
             } else {
                 invoker_accessible = false;
-                LOG(DEBUG) << "LOCKED"sv;
+                //LOG(DEBUG) << "LOCKED"sv;
             }
 
         }
@@ -505,7 +505,7 @@ namespace intercept {
     void invoker::_invoker_unlock::unlock() {
         if (!_unlocked) {
             if (_all) {
-                LOG(DEBUG) << "UNLOCKING ALL"sv;
+                //LOG(DEBUG) << "UNLOCKING ALL"sv;
                 std::unique_lock<std::recursive_mutex> invoke_lock(_instance->_invoke_mutex, std::defer_lock);
                 {
                     std::lock_guard<std::mutex> lock(_instance->_state_mutex);
@@ -515,7 +515,7 @@ namespace intercept {
                 }
                 _instance->_invoke_condition.notify_all();
             } else {
-                LOG(DEBUG) << "UNLOCKING"sv;
+                //LOG(DEBUG) << "UNLOCKING"sv;
                 std::lock_guard<std::mutex> lock(_instance->_state_mutex);
                 invoker_accessible = true;
             }

--- a/src/host/loader/loader.cpp
+++ b/src/host/loader/loader.cpp
@@ -79,7 +79,7 @@ namespace intercept {
     }
 
     bool loader::hook_function(std::string_view function_name_, void * hook_, unary_function & trampoline_) {
-        LOG(DEBUG) << "Attempting to hook unary function "sv << function_name_;
+        LOG(WARNING) << "Attempting to hook unary function "sv << function_name_;
         auto op = _unary_operators.find(function_name_);
         if (op != _unary_operators.end()) {
             uintptr_t op_ptr = op->second[0].procedure_ptr_addr;
@@ -91,7 +91,7 @@ namespace intercept {
     }
 
     bool loader::hook_function(std::string_view function_name_, void * hook_, binary_function & trampoline_) {
-        LOG(DEBUG) << "Attempting to hook binary function "sv << function_name_;
+        LOG(WARNING) << "Attempting to hook binary function "sv << function_name_;
         auto op = _binary_operators.find(function_name_);
         if (op != _binary_operators.end()) {
             uintptr_t op_ptr = op->second[0].procedure_ptr_addr;
@@ -103,7 +103,7 @@ namespace intercept {
     }
 
     bool loader::hook_function(std::string_view function_name_, void * hook_, nular_function & trampoline_) {
-        LOG(DEBUG) << "Attempting to hook nular function "sv << function_name_;
+        LOG(WARNING) << "Attempting to hook nular function "sv << function_name_;
         auto op = _nular_operators.find(function_name_);
         if (op != _nular_operators.end()) {
             uintptr_t op_ptr = op->second[0].procedure_ptr_addr;
@@ -115,7 +115,7 @@ namespace intercept {
     }
 
     bool loader::unhook_function(std::string function_name_, void * hook_, unary_function & trampoline_) {
-        LOG(DEBUG) << "Attempting to unhook unary function "sv << function_name_;
+        LOG(WARNING) << "Attempting to unhook unary function "sv << function_name_;
         if (&trampoline_ == nullptr)
             return false;
         auto op = _unary_operators.find(function_name_);
@@ -128,7 +128,7 @@ namespace intercept {
     }
 
     bool loader::unhook_function(std::string function_name_, void * hook_, binary_function & trampoline_) {
-        LOG(DEBUG) << "Attempting to unhook binary function "sv << function_name_;
+        //LOG(DEBUG) << "Attempting to unhook binary function "sv << function_name_;
         if (&trampoline_ == nullptr)
             return false;
         auto op = _binary_operators.find(function_name_);
@@ -141,7 +141,7 @@ namespace intercept {
     }
 
     bool loader::unhook_function(std::string function_name_, void * hook_, nular_function & trampoline_) {
-        LOG(DEBUG) << "Attempting to unhook nular function "sv << function_name_;
+        //LOG(DEBUG) << "Attempting to unhook nular function "sv << function_name_;
         if (&trampoline_ == nullptr)
             return false;
         auto op = _nular_operators.find(function_name_);


### PR DESCRIPTION
Debug logs were creating dozens of gigabytes of useless logfiles.
If you really need them because you are debugging you work with a self compiled build anyway and can just enable what you need.
Decreasing the easylogging loglevel to not print debug messages is not enough. As the loglevel is set at runtime. The compiler can't know the level at compiletime. Meaning even if debug logging is disabled the log function is still called. Which is a huge performance concern in stuff like Eventhandlers or invoker_lock