### PR TITLE
Ref swap for faster r_string move construct

### DIFF
--- a/src/client/headers/shared/containers.hpp
+++ b/src/client/headers/shared/containers.hpp
@@ -430,7 +430,7 @@ namespace intercept::types {
             if (!data())  return !other_ || !*other_; //empty?
         #ifdef __GNUC__
             return std::equal(_ref->cbegin(), _ref->cend(),
-                other, [](unsigned char l, unsigned char r) {return l == r || tolower(l) == tolower(r); });
+                other_, [](unsigned char l, unsigned char r) {return l == r || tolower(l) == tolower(r); });
         #else
             return _strcmpi(data(), other_) == 0;
         #endif
@@ -442,7 +442,7 @@ namespace intercept::types {
             if (data() == other_.data()) return true;
         #ifdef __GNUC__
             return std::equal(_ref->cbegin(), _ref->cend(),
-                other.data(), [](unsigned char l, unsigned char r) {return l == r || tolower(l) == tolower(r); });
+                other_.data(), [](unsigned char l, unsigned char r) {return l == r || tolower(l) == tolower(r); });
         #else
             return _strcmpi(data(), other_.data()) == 0;
         #endif
@@ -454,7 +454,7 @@ namespace intercept::types {
             if (other_.length() > _ref->size()) return false; //There is more data than we can even have
         #ifdef __GNUC__
             return std::equal(_ref->cbegin(), _ref->cend(),
-                other.data(), [](unsigned char l, unsigned char r) {return l == r || tolower(l) == tolower(r); });
+                other_.data(), [](unsigned char l, unsigned char r) {return l == r || tolower(l) == tolower(r); });
         #else
             return _strcmpi(data(), other_.data()) == 0;
         #endif
@@ -466,7 +466,7 @@ namespace intercept::types {
             if (other_.length() > _ref->size()) return false; //There is more data than we can even have
         #ifdef __GNUC__
             return std::equal(_ref->cbegin(), _ref->cend(),
-                other.data(), [](unsigned char l, unsigned char r) {return l == r || tolower(l) == tolower(r); });
+                other_.data(), [](unsigned char l, unsigned char r) {return l == r || tolower(l) == tolower(r); });
         #else
             return _strcmpi(data(), other_.data()) == 0;
         #endif
@@ -512,7 +512,7 @@ namespace intercept::types {
         bool compare_case_sensitive(const char *other_) const {
         #ifdef __GNUC__
             return !std::equal(_ref->cbegin(), _ref->cend(),
-                other, [](unsigned char l, unsigned char r) {return l == r; });
+                other_, [](unsigned char l, unsigned char r) {return l == r; });
         #else
             return strcmp(data(), other_) == 0;
         #endif
@@ -521,7 +521,7 @@ namespace intercept::types {
         bool compare_case_insensitive(const char *other_) const {//#TODO string_view variant with length checking
         #ifdef __GNUC__
             return !std::equal(_ref->cbegin(), _ref->cend(),
-                other, [](unsigned char l, unsigned char r) {return ::tolower(l) == ::tolower(r); });
+                other_, [](unsigned char l, unsigned char r) {return ::tolower(l) == ::tolower(r); });
         #else
             return _stricmp(data(), other_) == 0;
         #endif
@@ -547,30 +547,30 @@ namespace intercept::types {
             return std::hash<std::string_view>()(std::string_view(data(), _ref ? _ref->size() : 0u));
         }
 
-        r_string append(std::string_view _right) const {
+        r_string append(std::string_view right_) const {
             const auto my_length = length();
-            auto new_data = create(my_length + _right.length() + 1);//Space for terminating nullchar
+            auto new_data = create(my_length + right_.length() + 1);//Space for terminating nullchar
         #if __GNUC__
             std::copy_n(data(), my_length, new_data->data());
-            std::copy_n(_right.data(), _right.length(), new_data->data() + my_length);
+            std::copy_n(right_.data(), right_.length(), new_data->data() + my_length);
         #else
             memcpy_s(new_data->data(), new_data->size(), data(), my_length);//#TODO better use memcpy? does strncpy_s check for null chars? we don't want that
-            memcpy_s(new_data->data() + my_length, new_data->size() - my_length, _right.data(), _right.length());//#TODO better use memcpy? does strncpy_s check for null chars? we don't want that
+            memcpy_s(new_data->data() + my_length, new_data->size() - my_length, right_.data(), right_.length());//#TODO better use memcpy? does strncpy_s check for null chars? we don't want that
         #endif
-            new_data->data()[my_length + _right.length()] = 0;
+            new_data->data()[my_length + right_.length()] = 0;
             return r_string(new_data);
         }
-        r_string& append_modify(std::string_view _right) {
+        r_string& append_modify(std::string_view right_) {
             const auto my_length = length();
-            auto newData = create(my_length + _right.length() + 1);//Space for terminating nullchar
+            auto newData = create(my_length + right_.length() + 1);//Space for terminating nullchar
         #if __GNUC__
             std::copy_n(data(), my_length, newData->data());
-            std::copy_n(_right.data(), _right.length(), newData->data() + my_length);
+            std::copy_n(right_.data(), right_.length(), newData->data() + my_length);
         #else
             memcpy_s(newData->data(), newData->size(), data(), my_length);//#TODO better use memcpy? does strncpy_s check for null chars? we don't want that
-            memcpy_s(newData->data() + my_length, newData->size() - my_length, _right.data(), _right.length());//#TODO better use memcpy? does strncpy_s check for null chars? we don't want that
+            memcpy_s(newData->data() + my_length, newData->size() - my_length, right_.data(), right_.length());//#TODO better use memcpy? does strncpy_s check for null chars? we don't want that
         #endif
-            newData->data()[my_length + _right.length()] = 0;
+            newData->data()[my_length + right_.length()] = 0;
             _ref = newData;
             return *this;
         }
@@ -618,7 +618,7 @@ namespace intercept::types {
             if (len_ == 0 || *str == 0) return nullptr;
             compact_array<char> *string = compact_array<char>::create(len_ + 1);
         #if __GNUC__
-            std::copy_n(str, len, string->data());
+            std::copy_n(str, len_, string->data());
         #else
             strncpy_s(string->data(), string->size(), str, len_);//#TODO better use memcpy? does strncpy_s check for null chars? we don't want that
         #endif

--- a/src/client/headers/shared/containers.hpp
+++ b/src/client/headers/shared/containers.hpp
@@ -3,6 +3,7 @@
 #include <iostream>
 #include <algorithm>
 #include <optional>
+#include <cstring>
 
 namespace intercept::types {
     

--- a/src/client/headers/shared/containers.hpp
+++ b/src/client/headers/shared/containers.hpp
@@ -202,7 +202,11 @@ namespace intercept::types {
             if (old) old->release();//decrement reference and delete object if refcount == 0
             return *this;
         }
-
+        void swap(ref &other_) noexcept {
+            auto temp = other_._ref;
+            other_._ref = _ref;
+            _ref = temp;
+        }
         constexpr bool is_null() const noexcept { return _ref == nullptr; }
         void free() noexcept {
             if (!_ref) return;
@@ -365,8 +369,7 @@ namespace intercept::types {
         //}
         explicit r_string(compact_array<char>* dat_) noexcept : _ref(dat_) {}
         r_string(r_string&& move_) noexcept {
-            _ref = move_._ref;
-            move_._ref = nullptr;
+            _ref.swap(move_._ref);
         }
         r_string(const r_string& copy_) {
             _ref = copy_._ref;
@@ -375,8 +378,7 @@ namespace intercept::types {
         r_string& operator = (r_string&& move_) noexcept {
             if (this == &move_)
                 return *this;
-            _ref = move_._ref;
-            move_._ref = nullptr;
+            _ref.swap(move_._ref);
             return *this;
         }
 

--- a/src/client/headers/shared/types.hpp
+++ b/src/client/headers/shared/types.hpp
@@ -494,6 +494,7 @@ namespace intercept {
             }
             game_value(float val_);
             game_value(int val_);
+            game_value(size_t val_);
             game_value(bool val_);
             game_value(const std::string &val_);
             game_value(const r_string &val_);

--- a/src/client/headers/shared/types.hpp
+++ b/src/client/headers/shared/types.hpp
@@ -240,6 +240,12 @@ namespace intercept {
                 return *this;
             }
 
+            void swap(ref &other) {
+                auto temp = other._ref;
+                other._ref = _ref;
+                _ref = temp;
+            }
+
             constexpr bool is_null() const noexcept { return _ref == nullptr; }
             void free() noexcept {
                 if (!_ref) return;
@@ -363,8 +369,7 @@ namespace intercept {
             //}
             explicit r_string(compact_array<char>* dat) noexcept : _ref(dat) {}
             r_string(r_string&& _move) noexcept {
-                _ref = _move._ref;
-                _move._ref = nullptr;
+                _ref.swap(_move._ref);
             }
             r_string(const r_string& _copy) {
                 _ref = _copy._ref;
@@ -373,8 +378,7 @@ namespace intercept {
             r_string& operator = (r_string&& _move) noexcept {
                 if (this == &_move)
                     return *this;
-                _ref = _move._ref;
-                _move._ref = nullptr;
+                _ref.swap(_move._ref);
                 return *this;
             }
 

--- a/src/client/intercept/shared/types.cpp
+++ b/src/client/intercept/shared/types.cpp
@@ -477,7 +477,9 @@ namespace intercept {
             data = new game_data_number(val_);
         }
 
-        game_value::game_value(const int val_) : game_value(static_cast<float>(val_)) {}
+        game_value::game_value(int val_) : game_value(static_cast<float>(val_)) {}
+
+        game_value::game_value(size_t val_) : game_value(static_cast<float>(val_)) {}
 
         game_value::game_value(bool val_) {
             set_vtable(__vptr_def);


### PR DESCRIPTION
Current r_string move constructor still increases/modifies the refcount.
This add's a swap function that doesn't modify refcount. Thus faster