### PR TITLE
Accessible Game State and Other misc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ branches:
   - master
   - develop
 
+sudo: required
 dist: trusty
 language: python
 

--- a/src/client/headers/client/eventhandlers.hpp
+++ b/src/client/headers/client/eventhandlers.hpp
@@ -31,7 +31,7 @@ namespace intercept::client {
     /// @private
     struct EHIdentifier {
         int32_t internal_id;
-        float arma_eh_id;
+        int arma_eh_id;
         uint32_t EHIteration;
         uint8_t EHType;
         bool already_deleted = false;

--- a/src/client/headers/client/sqf/core.hpp
+++ b/src/client/headers/client/sqf/core.hpp
@@ -153,15 +153,15 @@ namespace intercept {
         void on_map_single_click(const game_value &params_, std::variant<sqf_string_const_ref_wrapper, std::reference_wrapper<const code>> command_);
         game_value on_show_new_object(const object &control_, sqf_string_const_ref command_);
         //eventhandler
-        float add_event_handler(const object &object_, sqf_string_const_ref type_, const code &command_);
-        float add_event_handler(const object &object_, sqf_string_const_ref type_, sqf_string_const_ref command_);
+        int add_event_handler(const object &object_, sqf_string_const_ref type_, const code &command_);
+        int add_event_handler(const object &object_, sqf_string_const_ref type_, sqf_string_const_ref command_);
         void remove_event_handler(const object &object_, sqf_string_const_ref event_, int index_);
-        float add_mission_event_handler(sqf_string_const_ref type_, const code &command_);
-        float add_mission_event_handler(sqf_string_const_ref type_, sqf_string_const_ref command_);
+        int add_mission_event_handler(sqf_string_const_ref type_, const code &command_);
+        int add_mission_event_handler(sqf_string_const_ref type_, sqf_string_const_ref command_);
         void remove_all_mission_event_handlers(sqf_string_const_ref value_);
         void remove_all_event_handlers(const object &value0_, sqf_string_const_ref value1_);
         void remove_all_mpevent_handlers(const object &value0_, sqf_string_const_ref value1_);
-        void remove_mission_event_handler(sqf_string_const_ref type_, float index_);
+        void remove_mission_event_handler(sqf_string_const_ref type_, int index_);
         int add_mp_event_handler(const object &object_, sqf_string_const_ref type_, sqf_string_const_ref expression_);
         int add_mp_event_handler(const object &object_, sqf_string_const_ref type_, const code &expression_);
         void remove_mp_event_handler(const object &object_, sqf_string_const_ref event_, int index_);

--- a/src/client/headers/client/sqf/ctrl.hpp
+++ b/src/client/headers/client/sqf/ctrl.hpp
@@ -153,8 +153,6 @@ namespace intercept {
         void ctrl_map_anim_clear(const control &value_);
         void ctrl_map_anim_commit(const control &value_);
         void ctrl_map_cursor(const control &ctrl_, sqf_string_const_ref default_cursor_, sqf_string_const_ref new_cursor_);
-        void ctrl_remove_all_event_handlers(const control &value0_, sqf_string_const_ref value1_);
-        void ctrl_remove_event_handler(const control &ctrl_, sqf_string_const_ref name_, float &id_);
         void ctrl_set_active_color(const control &ctrl_, const rv_color &color_);
         void ctrl_set_auto_scroll_delay(const control &value0_, float value1_);
         void ctrl_set_auto_scroll_rewind(const control &value0_, bool value1_);
@@ -188,8 +186,11 @@ namespace intercept {
         vector2 ctrl_map_screen_to_world(const control &ctrl_, const vector2 &screen_pos_);
 
         void ctrl_set_event_handler(const control &ctrl_, sqf_string_const_ref name_, sqf_string_const_ref command_);
-        float ctrl_add_event_handler(const control &ctrl_, sqf_string_const_ref name_, sqf_string_const_ref command_);
-        float ctrl_add_event_handler(const control &ctrl_, sqf_string_const_ref name_, const code &command_);
+        int ctrl_add_event_handler(const control &ctrl_, sqf_string_const_ref name_, sqf_string_const_ref command_);
+        int ctrl_add_event_handler(const control &ctrl_, sqf_string_const_ref name_, const code &command_);
+        void ctrl_remove_all_event_handlers(const control &value0_, sqf_string_const_ref value1_);
+        void ctrl_remove_event_handler(const control &ctrl_, sqf_string_const_ref name_, int id_);
+
 
         //listbox/combobox
         void lnb_delete_column(const control &ctrl_, float index_);

--- a/src/client/headers/shared/containers.hpp
+++ b/src/client/headers/shared/containers.hpp
@@ -370,10 +370,19 @@ namespace intercept::types {
             return ret;
         }
 
+        //Doesn't clear memory. use create_zero if you want that
         static compact_array* create(size_t number_of_elements_) {
             const size_t size = sizeof(compact_array) + sizeof(Type)*(number_of_elements_ - 1);//-1 because we already have one element in compact_array
             compact_array* buffer = reinterpret_cast<compact_array*>(Allocator::allocate(size));
         #pragma warning(suppress: 26409) //don't use new/delete
+            new (buffer) compact_array(number_of_elements_);
+            return buffer;
+        }
+        static compact_array* create_zero(size_t number_of_elements_) {
+            const size_t size = sizeof(compact_array) + sizeof(Type)*(number_of_elements_ - 1);//-1 because we already have one element in compact_array
+            compact_array* buffer = reinterpret_cast<compact_array*>(Allocator::allocate(size));
+        #pragma warning(suppress: 26409) //don't use new/delete
+            std::memset(buffer, 0, size);
             new (buffer) compact_array(number_of_elements_);
             return buffer;
         }
@@ -535,7 +544,7 @@ namespace intercept::types {
             return std::equal(_ref->cbegin(), _ref->cend(),
                 other_.data(), [](unsigned char l, unsigned char r) {return l == r || tolower(l) == tolower(r); });
         #else
-            return _strcmpi(data(), other_.data()) == 0;
+            return _strnicmp(data(), other_.data(), other_.length()) == 0;
         #endif
         }
 

--- a/src/client/headers/shared/containers.hpp
+++ b/src/client/headers/shared/containers.hpp
@@ -393,6 +393,23 @@ namespace intercept::types {
             std::copy(other.data(), other.data() + other.size(), buffer->data());
             return buffer;
         }
+
+        template<class _InIt>
+        static compact_array* create(_InIt beg, _InIt end) {
+            const size_t size = sizeof(compact_array) + sizeof(Type)*(std::distance(beg,end)-1);
+            compact_array* buffer = reinterpret_cast<compact_array*>(Allocator::allocate(size));
+            std::memset(buffer, 0, size);
+        #pragma warning(suppress: 26409) //don't use new/delete
+            new (buffer) compact_array(size);
+
+            size_t index = 0;
+            for (auto& i = beg; i < end; ++i) {
+                buffer->data()[index++] = *i;
+            }
+
+            return buffer;
+        }
+
         //Specialty function to copy less elements or to allocate more space
         static compact_array* create(const compact_array &other, size_t element_count) {
             const size_t size = other.size();

--- a/src/client/headers/shared/containers.hpp
+++ b/src/client/headers/shared/containers.hpp
@@ -124,7 +124,7 @@ namespace intercept::types {
 
 
     template<class Type, int Count, class Fallback = rv_allocator<Type>>
-    class rv_alloc_local : private Fallback {
+    class rv_allocator_local : private Fallback {
         //buffer will be aligned by this
         using buffer_type = int;
 

--- a/src/client/headers/shared/types.hpp
+++ b/src/client/headers/shared/types.hpp
@@ -400,6 +400,7 @@ namespace intercept {
         };
 
         class vm_context;
+        class game_data_namespace;
 
         class game_state {
         public:
@@ -413,26 +414,34 @@ namespace intercept {
             map_string_to_class<game_operators, auto_array<game_operators>> _scriptOperators;
             map_string_to_class<gsNular, auto_array<gsNular>> _scriptNulars;
 
+            auto_array<void*, rv_allocator_local<void*, 64>> dummy1;
 
-            void* stuff[69];//verify on x64
-
-            class game_evaluator {//refcounted
+            class game_evaluator : public refcount {//refcounted
             public:
-                   //vtable
-                //refcount
+                //See ArmaDebugEngine
+                class game_var_space : public serialize_class {
+                    //see ArmaDebugEngine
+                    //map_string_to_class<game_variable, auto_array<game_variable>> varspace;
+                    game_var_space* parent;
+                    bool dummy;
+                } *varspace;
+
                 //pointer to GameVarSpace //should be scope local variables
-                //int some number
-                //2 booleans
+                int dummy1;
+                bool dummy2;
+                bool dummy3;
                 // error enum
                 //r_string error text
                 //sourcedocpos see ArmaDebugEngine
             } *eval;
 
-             //global namespace 
-            //auto array of namespaces
-            //bool See ArmaDebugEngine I think it should have them
-            //bool
-            //VMContext*
+            ref<game_data_namespace> varspace; //Maybe currentNamespace?
+            auto_array<game_data_namespace*> namespaces; //mission/parsing/... namespace
+            bool dummy2;
+            bool onscreen_script_errors;
+            vm_context* current_context;
+
+            //callstack item types. auto_array of struct {void* to func; r_string name}
 
 
             game_data* create_gd_from_type(const sqf_script_type& type, param_archive* ar) const {
@@ -667,15 +676,32 @@ namespace intercept {
 
         class vm_context : public serialize_class {
         public:
-            //fill with dummy
-            bool serialenabled;
-            void* dummyu;
-            //sourcdoc;
-            //sourcdocpos;
-            //bool uicontext
-            //local malloc stack  #TODO implement local malloc thingy static memory in class
-            r_string name;
-            bool scheduled;
+            auto_array<void*, rv_allocator_local<void*, 64>> dummy1;
+            bool serialenabled; //disableSerialization -> true
+            void* dummyu; //Check debug engine for this. This might be useful
+
+            class source_doc {//dedmen/ArmaDebugEngine
+                uintptr_t vtable;
+            public:
+                r_string _fileName;
+                r_string _content;
+            } sdoc;
+
+            class source_doc_pos {//dedmen/ArmaDebugEngine
+                uintptr_t vtable;
+            public:
+                r_string _sourceFile;
+                int _sourceLine;
+
+                r_string _content;
+                int _pos;
+            } sdocpos;
+
+            const bool is_ui_context; //no touchy
+            auto_array<game_value, rv_allocator_local<game_value, 32>> scriptStack;
+
+            r_string name; //profiler might like this
+            const bool scheduled; //canSuspend
             bool dumm;
             bool dumm2; //undefined variables allowed?
             bool excp1;//throw break breakOut exitWith stuff

--- a/src/client/headers/shared/types.hpp
+++ b/src/client/headers/shared/types.hpp
@@ -977,21 +977,25 @@ namespace intercept {
 
         class game_instruction : public refcount {
         public:
-            struct sourcedocpos {//See ArmaDebugEngine for more info on this
-                uintptr_t vtable;
+            struct sourcedocpos : public serialize_class {//See ArmaDebugEngine for more info on this
                 r_string sourcefile;
                 uint32_t sourceline;
                 r_string content;
                 uint32_t pos;
+
+                serialization_return serialize(param_archive &ar) override {
+                    return serialization_return::unknown_error;
+                }
+
             } sdp;
 
 
             virtual bool exec(game_state& state, vm_context& t) = 0;
-            /// how data stack changes after the instruction is processed
             virtual int stack_size(void* t) const = 0;
-            // returns position in source code
+            //Leave this alone!
+        private:
             virtual bool bfunc() const { return false; }
-            /// text of the instruction (for disassembly, profiling etc.)
+        public:
             virtual r_string get_name() const = 0;
         };
 
@@ -1011,7 +1015,7 @@ namespace intercept {
             size_t hash() const { return __internal::pairhash(type_def, code_string); }
             r_string code_string;
             ref<compact_array<ref<game_instruction>>> instructions;
-            uint32_t _dummy1;
+            uint32_t _dummy1{1};
             uint32_t _dummy;
             bool is_final;
         };

--- a/src/client/headers/shared/types.hpp
+++ b/src/client/headers/shared/types.hpp
@@ -696,7 +696,7 @@ namespace intercept {
 
 
             void get_name(char *buffer, int len) const override {
-                strncpy_s(buffer, len, name.c_str(), len);
+                strncpy(buffer, name.c_str(), std::min(static_cast<size_t>(len),name.length()));
                 buffer[len - 1] = 0;
             }
 

--- a/src/client/headers/shared/types.hpp
+++ b/src/client/headers/shared/types.hpp
@@ -435,7 +435,7 @@ namespace intercept {
                 //sourcedocpos see ArmaDebugEngine
             } *eval;
 
-            ref<game_data_namespace> varspace; //Maybe currentNamespace?
+            game_data_namespace* varspace; //Maybe currentNamespace? is actually a ref<game_data_namespace>
             auto_array<game_data_namespace*> namespaces; //mission/parsing/... namespace
             bool dummy2;
             bool onscreen_script_errors;

--- a/src/client/intercept/CMakeLists.txt
+++ b/src/client/intercept/CMakeLists.txt
@@ -12,7 +12,7 @@ if(USE_ENGINE_TYPES)
 endif()
 
 
-
+add_definitions(/DNOMINMAX)
 add_definitions(/DINTERCEPT_NO_THREAD_SAFETY)
 
 set(INTERCEPT_NAME "intercept_client")

--- a/src/client/intercept/client/eventhandlers.cpp
+++ b/src/client/intercept/client/eventhandlers.cpp
@@ -12,11 +12,11 @@ namespace intercept::client {
 
     //Not in header because these are Internal functions that shall not be messed with
     /// @private
-    extern "C" DLLEXPORT void CDECL client_eventhandler(intercept::types::game_value& retVal, int ehType, int32_t uid, float handle, intercept::types::game_value args);
+    extern "C" DLLEXPORT void CDECL client_eventhandler(intercept::types::game_value& retVal, int ehType, int32_t uid, int handle, intercept::types::game_value args);
     /// @private
     extern "C" DLLEXPORT void CDECL client_eventhandlers_clear();
     /// @private
-    void client_eventhandler(intercept::types::game_value& retVal, int ehType, int32_t uid, float handle, game_value args) {
+    void client_eventhandler(intercept::types::game_value& retVal, int ehType, int32_t uid, int handle, game_value args) {
         switch (static_cast<eventhandler_type>(ehType)) {
             case eventhandler_type::mission: {
                 auto found = funcMapMissionEH.find({uid, handle, EHIteration });
@@ -182,7 +182,7 @@ namespace intercept::client {
                               + std::to_string(static_cast<uint32_t>(eventhandler_type::mission)) + ","
                               + std::to_string(uid) + ","
                               + "_thisEventHandler] InterceptClientEvent [_this]";
-        float ehid = intercept::sqf::add_mission_event_handler(static_cast<sqf_string_const_ref>(typeStr), command);
+        int ehid = intercept::sqf::add_mission_event_handler(static_cast<sqf_string_const_ref>(typeStr), command);
 
         return {uid, ehid, EHIteration, static_cast<uint8_t>(type) };
     }
@@ -497,7 +497,7 @@ namespace intercept::client {
                               + std::to_string(static_cast<uint32_t>(eventhandler_type::object)) + ","
                               + std::to_string(uid) + ","
                               + "_thisEventHandler] InterceptClientEvent [_this]";
-        float ehid = intercept::sqf::add_event_handler(obj, static_cast<sqf_string_const_ref>(typeStr), command);
+        int ehid = intercept::sqf::add_event_handler(obj, static_cast<sqf_string_const_ref>(typeStr), command);
 
         return {uid, ehid, EHIteration, static_cast<uint8_t>(type) };
     }
@@ -510,7 +510,7 @@ namespace intercept::client {
             case eventhandlers_object::HitPart: typeStr = "HitPart"sv; break;
         default:;
         }
-        sqf::remove_event_handler(obj, static_cast<sqf_string_const_ref>(typeStr), static_cast<int>(handle.arma_eh_id));
+        sqf::remove_event_handler(obj, static_cast<sqf_string_const_ref>(typeStr), handle.arma_eh_id);
     }
 #pragma endregion
 
@@ -572,7 +572,7 @@ namespace intercept::client {
                               + std::to_string(static_cast<uint32_t>(eventhandler_type::ctrl)) + ","
                               + std::to_string(uid) + ","
                               + "_thisEventHandler] InterceptClientEvent [_this]";
-        float ehid = intercept::sqf::ctrl_add_event_handler(ctrl, static_cast<sqf_string>(typeStr), command);
+        int ehid = intercept::sqf::ctrl_add_event_handler(ctrl, static_cast<sqf_string>(typeStr), command);
 
         return {uid, ehid, EHIteration, static_cast<uint8_t>(type) };
     }
@@ -631,7 +631,7 @@ namespace intercept::client {
             + std::to_string(static_cast<uint32_t>(eventhandler_type::mp)) + ","
             + std::to_string(uid) + ","
             + "_thisEventHandler] InterceptClientEvent [_this]";
-        float ehid = intercept::sqf::add_mp_event_handler(unit, static_cast<sqf_string_const_ref>(typeStr), command);
+        int ehid = intercept::sqf::add_mp_event_handler(unit, static_cast<sqf_string_const_ref>(typeStr), command);
 
         return { uid, ehid, EHIteration, static_cast<uint8_t>(type) };
     }
@@ -698,7 +698,7 @@ namespace intercept::client {
             + std::to_string(static_cast<uint32_t>(eventhandler_type::display)) + ","
             + std::to_string(uid) + ","
             + "_thisEventHandler] InterceptClientEvent [_this]";
-        float ehid = intercept::sqf::display_add_event_handler(disp, static_cast<sqf_string_const_ref>(typeStr), command);
+        int ehid = intercept::sqf::display_add_event_handler(disp, static_cast<sqf_string_const_ref>(typeStr), command);
 
         return { uid, ehid, EHIteration, static_cast<uint8_t>(type) };
     }
@@ -720,12 +720,12 @@ namespace intercept::client {
     std::unordered_map<EHIdentifier, std::shared_ptr<std::function<types::game_value(types::game_value_parameter)>>, EHIdentifier_hasher> customCallbackMap;
 
     std::pair<std::string, EHIdentifierHandle> generate_custom_callback(std::function<game_value(game_value_parameter)> fnc) {
-        static float ehId = -16777210.f;
+        static int ehId = -16777210;
         std::default_random_engine rng(std::random_device{}());
         std::uniform_int_distribution<int32_t> dist(-16777215, 16777215);
         auto uid = dist(rng);
 
-        ehId += 1.f;
+        ehId++;
         EHIdentifier ident{ uid, ehId, 0, 0 };
 
         customCallbackMap[ident] = std::make_shared<std::function<game_value(game_value_parameter)>>(fnc);

--- a/src/client/intercept/client/sqf/core.cpp
+++ b/src/client/intercept/client/sqf/core.cpp
@@ -822,14 +822,14 @@ namespace intercept {
             host::functions.invoke_raw_binary(__sqf::binary__removeeventhandler__object__array__ret__nothing, object_, params_right);
         }
 
-        float add_event_handler(const object &object_, sqf_string_const_ref type_, const code &command_) {
+        int add_event_handler(const object &object_, sqf_string_const_ref type_, const code &command_) {
             game_value args({type_,
                              command_});
 
             return host::functions.invoke_raw_binary(__sqf::binary__addeventhandler__object__array__ret__nothing_scalar, object_, args);
         }
 
-        float add_event_handler(const object &object_, sqf_string_const_ref type_, sqf_string_const_ref command_) {
+        int add_event_handler(const object &object_, sqf_string_const_ref type_, sqf_string_const_ref command_) {
             game_value args({type_,
                              command_});
 
@@ -880,21 +880,21 @@ namespace intercept {
             host::functions.invoke_raw_binary(__sqf::binary__removeallmpeventhandlers__object__string__ret__nothing, value0_, value1_);
         }
 
-        float add_mission_event_handler(sqf_string_const_ref type_, const code &command_) {
+        int add_mission_event_handler(sqf_string_const_ref type_, const code &command_) {
             game_value params({type_,
                                command_});
 
             return host::functions.invoke_raw_unary(__sqf::unary__addmissioneventhandler__array__ret__nothing_scalar, params);
         }
 
-        float add_mission_event_handler(sqf_string_const_ref type_, sqf_string_const_ref command_) {
+        int add_mission_event_handler(sqf_string_const_ref type_, sqf_string_const_ref command_) {
             game_value params({type_,
                                command_});
 
             return host::functions.invoke_raw_unary(__sqf::unary__addmissioneventhandler__array__ret__nothing_scalar, params);
         }
 
-        void remove_mission_event_handler(sqf_string_const_ref type_, float index_) {
+        void remove_mission_event_handler(sqf_string_const_ref type_, int index_) {
             game_value params({type_,
                                index_});
 

--- a/src/client/intercept/client/sqf/ctrl.cpp
+++ b/src/client/intercept/client/sqf/ctrl.cpp
@@ -1259,21 +1259,21 @@ namespace intercept {
             return __helpers::__convert_to_vector<float>(ret);
         }
 
-        float ctrl_add_event_handler(const control &ctrl_, sqf_string_const_ref name_, sqf_string_const_ref command_) {
+        int ctrl_add_event_handler(const control &ctrl_, sqf_string_const_ref name_, sqf_string_const_ref command_) {
             game_value params({name_,
                                command_});
 
             return host::functions.invoke_raw_binary(__sqf::binary__ctrladdeventhandler__control__array__ret__scalar, ctrl_, params);
         }
 
-        float ctrl_add_event_handler(const control &ctrl_, sqf_string_const_ref name_, const code &command_) {
+        int ctrl_add_event_handler(const control &ctrl_, sqf_string_const_ref name_, const code &command_) {
             game_value params({name_,
                                command_});
 
             return host::functions.invoke_raw_binary(__sqf::binary__ctrladdeventhandler__control__array__ret__scalar, ctrl_, params);
         }
 
-        void ctrl_remove_event_handler(const control &ctrl_, sqf_string_const_ref name_, float &id_) {
+        void ctrl_remove_event_handler(const control &ctrl_, sqf_string_const_ref name_, int id_) {
             game_value params({name_,
                                id_});
 

--- a/src/client/intercept/shared/types.cpp
+++ b/src/client/intercept/shared/types.cpp
@@ -393,7 +393,7 @@ namespace intercept {
                 return nullptr;
             }
 
-            auto gs = reinterpret_cast<intercept::__internal::game_state *>(ar._parameters.front());
+            auto gs = reinterpret_cast<game_state *>(ar._parameters.front());
             return gs->create_gd_from_type(_type, &ar);
         }
 
@@ -590,20 +590,39 @@ namespace intercept {
         }
 
         game_value::operator int() const {
-            if (data)
+            if (data) {
+            #ifdef INTERCEPT_SAFE_CONVERSIONS
+                const auto type = data->get_vtable();
+                if (data->get_vtable() == game_data_number::type_def)
+                    throw game_value_conversion_error("Invalid conversion to scalar");
+            #endif
                 return static_cast<int>(data->get_as_number());
+            }
+                
             return 0;
         }
 
         game_value::operator float() const {
-            if (data)
+            if (data) {
+            #ifdef INTERCEPT_SAFE_CONVERSIONS
+                const auto type = data->get_vtable();
+                if (data->get_vtable() == game_data_number::type_def)
+                    throw game_value_conversion_error("Invalid conversion to scalar");
+            #endif
                 return data->get_as_number();
+            }
             return 0.f;
         }
 
         game_value::operator bool() const {
-            if (data)
+            if (data) {
+            #ifdef INTERCEPT_SAFE_CONVERSIONS
+                const auto type = data->get_vtable();
+                if (data->get_vtable() == game_data_bool::type_def)
+                    throw game_value_conversion_error("Invalid conversion to scalar");
+            #endif
                 return data->get_as_bool();
+            }
             return false;
         }
 
@@ -659,7 +678,7 @@ namespace intercept {
             if (data) {
                 if (data->get_vtable() != game_data_array::type_def) throw game_value_conversion_error("Invalid array access");
                 auto& array = data->get_as_array();
-                if (array.count() >= i_)
+                if (array.count() > i_)
                     return array[i_];
             }
             static game_value dummy;//else we would return a temporary.
@@ -671,7 +690,7 @@ namespace intercept {
             if (data) {
                 if (data->get_vtable() != game_data_array::type_def) return *this;
                 auto& array = data->get_as_array();
-                if (array.count() >= i_)
+                if (array.count() > i_)
                     return array[i_];
             }
             return {};

--- a/src/host/extensions/extensions.cpp
+++ b/src/host/extensions/extensions.cpp
@@ -43,13 +43,16 @@ namespace intercept {
         };
         functions.get_pbo_files_list = client_function_defs::get_pbo_files_list;
 
-        std::string arg_line = _searcher.get_command_line();
+        std::string arg_line = search::plugin_searcher::get_command_line();
         std::transform(arg_line.begin(), arg_line.end(), arg_line.begin(), ::tolower);
         if (arg_line.find("-intreloadall"sv) != std::string::npos) {
             do_reload = true;
-        } else {
-            do_reload = false;
         }
+
+        if (arg_line.find("-intignorecert"sv) != std::string::npos) {
+            ignore_cert_fail = true;
+        }
+
     }
 
     extensions::~extensions() {
@@ -126,6 +129,14 @@ namespace intercept {
                 LOG(ERROR, "PluginLoad failed, code signing certificate invalid [{}]", path_);
             }
         }
+    #ifdef _DEBUG 
+        if (ignore_cert_fail && security_class != cert::signing::security_class::core) {
+            security_class = cert::signing::security_class::core;
+            LOG(WARNING, "Ignoring Certificate and granting core-level access [{}]", path_);
+        }
+    #endif
+
+
     #endif
 
 

--- a/src/host/extensions/extensions.hpp
+++ b/src/host/extensions/extensions.hpp
@@ -303,7 +303,9 @@ namespace intercept {
         */
         std::map<module::plugin_interface_identifier, module::plugin_interface> exported_interfaces;
 
-        bool do_reload;
+        bool do_reload = false;
+
+        bool ignore_cert_fail = false;
 
         cert::signing::security_class get_module_security_class(uintptr_t mod_base) {
             auto found = _module_security_classes.find(mod_base);

--- a/src/host/extensions/extensions.hpp
+++ b/src/host/extensions/extensions.hpp
@@ -54,7 +54,7 @@ namespace intercept {
         typedef void(CDECL *on_signal_func)(game_value_parameter this_);
         typedef void(CDECL *on_interface_unload_func)(r_string name_);
         typedef void(CDECL *register_interfaces_func)();
-        typedef void(CDECL *client_eventhandler_func)(game_value& retVal, int ehType, int32_t uid, float handle, game_value args);
+        typedef void(CDECL *client_eventhandler_func)(game_value& retVal, int ehType, int32_t uid, int handle, game_value args);
         typedef void(CDECL *client_eventhandlers_clear_func)();
         typedef bool(CDECL *is_signed_function)();
 

--- a/src/host/invoker/sqf_functions.cpp
+++ b/src/host/invoker/sqf_functions.cpp
@@ -139,7 +139,7 @@ intercept::types::registered_sqf_function intercept::sqf_functions::registerFunc
     const auto test = findBinary("getvariable", GameDataType::OBJECT, GameDataType::ARRAY);
 
     auto operators = findOperators(std::string(name));
-    auto gs = reinterpret_cast<__internal::game_state*>(_registerFuncs._gameState);
+    auto gs = reinterpret_cast<game_state*>(_registerFuncs._gameState);
 
     if (!operators) {
         auto table = gs->_scriptOperators.get_table_for_key(lowerName.c_str());
@@ -230,7 +230,7 @@ intercept::types::registered_sqf_function intercept::sqf_functions::registerFunc
     std::transform(lowerName.begin(), lowerName.end(), lowerName.begin(), ::tolower);
 
     auto functions = findFunctions(std::string(name));
-    auto gs = reinterpret_cast<__internal::game_state*>(_registerFuncs._gameState);
+    auto gs = reinterpret_cast<game_state*>(_registerFuncs._gameState);
 
     if (!functions) {
         if (!_canRegister) throw std::logic_error("Can only register SQF Commands on preStart");
@@ -307,7 +307,7 @@ intercept::types::registered_sqf_function intercept::sqf_functions::registerFunc
     if (!_canRegister && intercept::cert::current_security_class != cert::signing::security_class::core) throw std::logic_error("Can only register SQF Commands on preStart");
     if (name.length() > 256) throw std::length_error("intercept::sqf_functions::registerFunction name can maximum be 256 chars long");
 
-    auto gs = reinterpret_cast<__internal::game_state*>(_registerFuncs._gameState);
+    auto gs = reinterpret_cast<game_state*>(_registerFuncs._gameState);
 
 
     sqf_script_type retType{ _registerFuncs._type_vtable,_registerFuncs._types[static_cast<size_t>(return_arg_type)],nullptr };
@@ -406,7 +406,7 @@ bool sqf_functions::unregisterFunction(const std::shared_ptr<registered_sqf_func
         return false;
     }
 
-    auto gs = reinterpret_cast<__internal::game_state*>(_registerFuncs._gameState);
+    auto gs = reinterpret_cast<game_state*>(_registerFuncs._gameState);
     switch (shared->_type) {
         case functionType::sqf_nular: {
             auto table = gs->_scriptNulars.get_table_for_key(shared->_name.c_str());
@@ -452,7 +452,7 @@ bool sqf_functions::unregisterFunction(const std::shared_ptr<registered_sqf_func
 std::pair<types::GameDataType, sqf_script_type>  intercept::sqf_functions::registerType(std::string_view name, std::string_view localizedName, std::string_view description, std::string_view typeName, script_type_info::createFunc cf) {
     if (!_canRegister) throw std::runtime_error("Can only register SQF Types on preStart");
     if (name.length() > 128) throw std::length_error("intercept::sqf_functions::registerType name can maximum be 128 chars long");
-    auto gs = reinterpret_cast<__internal::game_state*>(_registerFuncs._gameState);
+    auto gs = reinterpret_cast<game_state*>(_registerFuncs._gameState);
 
     auto newType = rv_allocator<script_type_info>::create_single(
     #ifdef __linux__
@@ -470,7 +470,7 @@ std::pair<types::GameDataType, sqf_script_type>  intercept::sqf_functions::regis
 }
 
 intercept::__internal::gsNular* intercept::sqf_functions::findNular(std::string name) const {
-    auto gs = reinterpret_cast<__internal::game_state*>(_registerFuncs._gameState);
+    auto gs = reinterpret_cast<game_state*>(_registerFuncs._gameState);
     std::transform(name.begin(), name.end(), name.begin(), ::tolower);
 
     auto& found = gs->_scriptNulars.get(name.c_str());
@@ -518,7 +518,7 @@ intercept::__internal::gsOperator* intercept::sqf_functions::findBinary(std::str
 }
 
 intercept::__internal::game_operators* intercept::sqf_functions::findOperators(std::string name) const {
-    auto gs = reinterpret_cast<__internal::game_state*>(_registerFuncs._gameState);
+    auto gs = reinterpret_cast<game_state*>(_registerFuncs._gameState);
     std::transform(name.begin(), name.end(), name.begin(), ::tolower);
 
     auto& found = gs->_scriptOperators.get(name.c_str());
@@ -527,7 +527,7 @@ intercept::__internal::game_operators* intercept::sqf_functions::findOperators(s
 }
 
 intercept::__internal::game_functions* intercept::sqf_functions::findFunctions(std::string name) const {
-    auto gs = reinterpret_cast<__internal::game_state*>(_registerFuncs._gameState);
+    auto gs = reinterpret_cast<game_state*>(_registerFuncs._gameState);
     std::transform(name.begin(), name.end(), name.begin(), ::tolower);
 
     auto& found = gs->_scriptFunctions.get(name.c_str());

--- a/src/host/loader/loader.hpp
+++ b/src/host/loader/loader.hpp
@@ -220,7 +220,7 @@ namespace intercept {
         */
         sqf_register_functions _sqf_register_funcs;
 
-        __internal::game_state* game_state;
+        game_state* game_state_ptr;
         uintptr_t evaluate_script_function;
         uintptr_t varset_function;
 


### PR DESCRIPTION
- Made GameState class publicly accessible (First parameter to a RSQF function is currently a uintptr_t. That really is a `const GameState*`)
- Added Safe conversions thingy. Define `INTERCEPT_SAFE_CONVERSIONS` and conversions to invalid types (For example trying to convert a string to a number) will throw an exception (https://github.com/intercept/intercept/pull/194/commits/89caa939299c771c749053f4c8fc2927133fad78#diff-205e20fbe0dd07548a5e9185a3bf00f6R594)
- Fixed off by one error when trying to get a Array element out of a GameValue (https://github.com/intercept/intercept/pull/194/commits/89caa939299c771c749053f4c8fc2927133fad78#diff-205e20fbe0dd07548a5e9185a3bf00f6L662) If you try to get value[2] out of a array with 2 elements this safety check will fail and it will try to access the non-existend value

- Added local memory allocator (on stack/in class) which is needed for some things in GameState. Might not perfectly match engine behaviour on Linux yet (**Needs Linux test**)
- Added support for custom allocator in auto_array

- Added more data to GameState class that allows more in-depth interaction with the scripting engine including direct access to namespaces, direct access to the script stack (Don't touch that), the ability to throw custom SQF exceptions (try/catch) from within your RSQF function, the ability to theoretically create your own custom script errors (the ones that are logged to RPT)

- Fixed possible buffer overrun error on r_string comparison
- Added ability to create compact_array from arbitrary iterators
- Added option to disable Plugin Certificate checks in Debug mode (Compile Intercept core in debug mode and add `-intIgnoreCert` startparameter to Arma). This will declare any plugin as signed by the core certificate allowing you to overwrite RSQF functions and access other Limited functionality.
- Added proper iterators for compact_array so that you can use std::transform/std::copy without warnings/errors

- **Plugin breaking Change** Changed eventhandler ID's to be signed integers instead of floats (https://github.com/intercept/intercept/pull/194/commits/1177d9a668241efb1619f8ad0f89b3309baa0a0f)
