### PR TITLE
Add config_entry iterator

### DIFF
--- a/CMakeInclude.txt
+++ b/CMakeInclude.txt
@@ -1,0 +1,30 @@
+#You can use include this file in your Intercept Plugins CMakeFile to add Intercept sources to your project.
+
+#Example:
+# set(INTERCEPT_NETWORK_NAME "intercept-network")
+# add_library(${INTERCEPT_NETWORK_NAME} SHARED)
+# set_property(GLOBAL PROPERTY INTERCEPT_CLIENT_TARGET ${INTERCEPT_NETWORK_NAME})
+# include(3rdParty/intercept/CMakeInclude.txt)
+
+
+
+get_property(INTERCEPT_CLIENT_TARGET GLOBAL PROPERTY INTERCEPT_CLIENT_TARGET)
+
+message("Including Intercept for project: '${INTERCEPT_CLIENT_TARGET}'")
+
+set(INTERCEPT_CLIENT_PATH "${CMAKE_CURRENT_LIST_DIR}/src/client")
+
+set(INTERCEPT_INCLUDE_PATH "${INTERCEPT_CLIENT_PATH}/headers" "${INTERCEPT_CLIENT_PATH}/headers/shared" "${INTERCEPT_CLIENT_PATH}/headers/client/" "${INTERCEPT_CLIENT_PATH}/headers/client/sqf")
+
+file(GLOB INTERCEPT_CLIENT_SOURCES "${INTERCEPT_CLIENT_PATH}/intercept/client/*.cpp"  "${INTERCEPT_CLIENT_PATH}/intercept/client/sqf/*.cpp" "${INTERCEPT_CLIENT_PATH}/intercept/shared/*.cpp")
+SOURCE_GROUP("intercept" FILES ${INTERCEPT_CLIENT_SOURCES})
+
+target_include_directories(${INTERCEPT_CLIENT_TARGET} PUBLIC ${INTERCEPT_INCLUDE_PATH})
+target_sources(${INTERCEPT_CLIENT_TARGET} PUBLIC ${INTERCEPT_CLIENT_SOURCES})
+target_compile_definitions(${INTERCEPT_CLIENT_TARGET} PUBLIC INTERCEPT_NO_THREAD_SAFETY)
+
+
+
+if(USE_ENGINE_TYPES)
+    target_compile_definitions(${INTERCEPT_CLIENT_TARGET} PUBLIC INTERCEPT_SQF_STRTYPE_RSTRING)
+endif()

--- a/src/client/headers/client/sqf/config.hpp
+++ b/src/client/headers/client/sqf/config.hpp
@@ -104,9 +104,8 @@ namespace intercept {
             config_entry operator[](sqf_string_const_ref entry_) const { return *this >> entry_; }
             config_entry operator[](size_t index_) const;
             size_t count() const;
-            iterator begin() const { return iterator(*this); }
-            iterator end() const { return iterator(*this,count()-1); }
-
+            iterator begin() const;
+            iterator end() const;
 
 
             operator config &() const;

--- a/src/client/headers/client/sqf/config.hpp
+++ b/src/client/headers/client/sqf/config.hpp
@@ -20,19 +20,99 @@ namespace intercept {
     namespace sqf {
         class config_entry {
         public:
+
+
+            class iterator {
+                const config_entry* p_;
+                size_t index{0};
+
+            public:
+                using iterator_category = std::random_access_iterator_tag;
+                using value_type = config_entry;
+                using difference_type = ptrdiff_t;
+                using pointer = config_entry *;
+                using reference = config_entry &;
+
+                iterator() : p_(nullptr) {}
+                explicit iterator(const config_entry &p) noexcept : p_(&p) {}
+                explicit iterator(const config_entry &p, size_t index_) noexcept : p_(&p), index(index_) {}
+                iterator(const iterator &other) noexcept : p_(other.p_) {}
+                iterator &operator=(const iterator &other) {
+                    p_ = other.p_;
+                    return *this;
+                }
+                iterator &operator++() noexcept {
+                    ++index;
+                    return *this;
+                }  // prefix++
+                iterator operator++(int) {
+                    iterator tmp(*this);
+                    ++(*this);
+                    return tmp;
+                }  // postfix++
+                iterator &operator--() noexcept {
+                    --index;
+                    return *this;
+                }  // prefix--
+                iterator operator--(int) {
+                    iterator tmp(*this);
+                    --(*this);
+                    return tmp;
+                }  // postfix--
+
+                void operator+=(const std::size_t &n) { index += n; }
+                void operator+=(const iterator &other) { index += other.index; }
+                iterator operator+(const std::size_t &n) const {
+                    iterator tmp(*this);
+                    tmp += n;
+                    return tmp;
+                }
+                iterator operator+(const iterator &other) const {
+                    iterator tmp(*this);
+                    tmp += other;
+                    return tmp;
+                }
+
+                void operator-=(const std::size_t &n) noexcept { index -= n; }
+                void operator-=(const iterator &other) noexcept { index -= other.index; }
+                iterator operator-(const std::size_t &n) const {
+                    iterator tmp(*this);
+                    tmp -= n;
+                    return tmp;
+                }
+                std::size_t operator-(const iterator &other) const noexcept { return index - other.index; }
+
+                bool operator<(const iterator &other) const noexcept { return (index - other.index) < 0; }
+                bool operator<=(const iterator &other) const noexcept { return (index - other.index) <= 0; }
+                bool operator>(const iterator &other) const noexcept { return (index - other.index) > 0; }
+                bool operator>=(const iterator &other) const noexcept { return (index - other.index) >= 0; }
+                bool operator==(const iterator &other) const noexcept { return index == other.index; }
+                bool operator!=(const iterator &other) const noexcept { return index != other.index; }
+
+                const config_entry &operator*() const noexcept { return p_[index]; }
+                const config_entry *operator->() const noexcept { return &(p_[index]); }
+            };
+
             config_entry();
             config_entry(types::config entry_);
             config_entry(config_entry const &copy_);
             config_entry(config_entry &&move_) noexcept;
             config_entry &operator=(const config_entry &copy_) = default;
             config_entry &operator=(config_entry &&move_) noexcept;
-            config_entry operator>>(sqf_string_const_ref entry_);
+            bool operator==(const config_entry &other_) const;
+            config_entry operator>>(sqf_string_const_ref entry_) const;
+            config_entry operator[](sqf_string_const_ref entry_) const { return *this >> entry_; }
+            config_entry operator[](size_t index_) const;
+            size_t count() const;
+            iterator begin() const { return iterator(*this); }
+            iterator end() const { return iterator(*this,count()-1); }
 
-            operator config &();
 
+
+            operator config &() const;
         protected:
-            types::config _config_entry;
-            bool _initialized;
+            mutable types::config _config_entry;
+            mutable bool _initialized;
         };
 
         std::vector<config> config_hierarchy(const config &config_entry_);

--- a/src/client/headers/shared/containers.hpp
+++ b/src/client/headers/shared/containers.hpp
@@ -12,24 +12,22 @@
 #undef max
 
 namespace intercept::types {
-    
-#pragma region Allocator
 
+#pragma region Allocator
 
     namespace __internal {
         void* rv_allocator_allocate_generic(size_t _size);
         void rv_allocator_deallocate_generic(void* _Ptr);
         void* rv_allocator_reallocate_generic(void* _Ptr, size_t _size);
-    }
+    }  // namespace __internal
 
-    template<class Type>
+    template <class Type>
     class rv_allocator {
     public:
-
         using value_type = Type;
 
-        using pointer = value_type *;
-        using const_pointer = const value_type *;
+        using pointer = value_type*;
+        using const_pointer = const value_type*;
 
         using reference = value_type&;
         using const_reference = const value_type&;
@@ -40,23 +38,20 @@ namespace intercept::types {
         using propagate_on_container_move_assignment = std::true_type;
         using is_always_equal = std::true_type;
 
-
-        template<class Other>
+        template <class Other>
         using rebind = rv_allocator<Other>;
 
-        template<class Other>
+        template <class Other>
         using rebind_alloc = rv_allocator<Other>;
 
-        template<class Other>
+        template <class Other>
         using rebind_traits = std::allocator_traits<rv_allocator<Other>>;
 
         rv_allocator() = default;
-        template<class Other>
+        template <class Other>
         rv_allocator(const rv_allocator<Other>&) {}
-        template<class Other>
+        template <class Other>
         rv_allocator(rv_allocator<Other>&&) {}
-
-       
 
         static void deallocate(Type* _Ptr, size_t = 0) {
             return __internal::rv_allocator_deallocate_generic(_Ptr);
@@ -68,7 +63,7 @@ namespace intercept::types {
 
         static void destroy(Type* _Ptr, size_t size_) {
             for (size_t i = 0; i < size_; ++i) {
-            #pragma warning(suppress: 26409)
+#pragma warning(suppress : 26409)
                 (_Ptr + i)->~Type();
             }
         }
@@ -86,11 +81,11 @@ namespace intercept::types {
         //This only allocates the memory! This will not be initialized to 0 and the allocated object will not have it's constructor called!
         //use the create* Methods instead
         static Type* allocate(const size_t count_) {
-            return reinterpret_cast<Type*>(__internal::rv_allocator_allocate_generic(sizeof(Type)*count_));
+            return reinterpret_cast<Type*>(__internal::rv_allocator_allocate_generic(sizeof(Type) * count_));
         }
 
         //Allocates and Initializes one Object
-        template<class... _Types>
+        template <class... _Types>
         static Type* create_single(_Types&&... _Args) {
             auto ptr = allocate(1);
             ::new (ptr) Type(std::forward<_Types>(_Args)...);
@@ -105,7 +100,7 @@ namespace intercept::types {
             auto ptr = allocate(count_);
 
             for (size_t i = 0; i < count_; ++i) {
-            #pragma warning(suppress: 26409)
+#pragma warning(suppress : 26409)
                 ::new (ptr + i) Type();
             }
 
@@ -121,12 +116,12 @@ namespace intercept::types {
         }
 
         static Type* reallocate(Type* ptr_, const size_t count_) {
-            return reinterpret_cast<Type*>(__internal::rv_allocator_reallocate_generic(ptr_, sizeof(Type)*count_));
+            return reinterpret_cast<Type*>(__internal::rv_allocator_reallocate_generic(ptr_, sizeof(Type) * count_));
         }
     };
 
     class rv_pool_allocator {
-        [[maybe_unused]] char pad_0x0000[0x24]; //0x0000
+        [[maybe_unused]] char pad_0x0000[0x24];  //0x0000
     public:
         const char* _allocName;
 
@@ -138,24 +133,22 @@ namespace intercept::types {
 
         void* allocate(size_t count);
         void deallocate(void* data);
-
     };
 
-
-    template<class Type, int Count, class Fallback = rv_allocator<Type>>
+    template <class Type, int Count, class Fallback = rv_allocator<Type>>
     class rv_allocator_local : private Fallback {
         //buffer will be aligned by this
         using buffer_type = int;
 
         //Raw size of buffer in bytes
-        static const size_t buffersize_bytes = (Count* sizeof(Type));
+        static const size_t buffersize_bytes = (Count * sizeof(Type));
         //Raw size in count of buffer_type elements
         static const size_t buffersize_count = (buffersize_bytes + sizeof(buffer_type) - 1) / sizeof(buffer_type);
         int dummy{0};
-        buffer_type buf[buffersize_count]{ 0 };
-        bool has_data{ false };
-    public:
+        buffer_type buf[buffersize_count]{0};
+        bool has_data{false};
 
+    public:
         Type* allocate(size_t count_) {
             if (count_ <= Count && !has_data) {
                 has_data = true;
@@ -171,12 +164,14 @@ namespace intercept::types {
             return Fallback::reallocate(ptr_, count_);
         }
         void deallocate(Type* ptr_, size_t count_ = 1) {
-            if (ptr_ != reinterpret_cast<Type*>(buf)) Fallback::deallocate(ptr_, count_);
-            else has_data = false;
+            if (ptr_ != reinterpret_cast<Type*>(buf))
+                Fallback::deallocate(ptr_, count_);
+            else
+                has_data = false;
         }
 
         //Allocates and Initializes one Object
-        template<class... _Types>
+        template <class... _Types>
         Type* create_single(_Types&&... _Args) {
             auto ptr = allocate(1);
             ::new (ptr) Type(std::forward<_Types>(_Args)...);
@@ -195,14 +190,13 @@ namespace intercept::types {
 
 #pragma endregion
 
-
 #pragma region Refcounting
 
     class refcount_base {
     public:
         constexpr refcount_base() noexcept : _refcount(0) {}
-        constexpr refcount_base(const refcount_base &) noexcept : _refcount(0) {}
-        constexpr void operator = (const refcount_base &) const noexcept {}
+        constexpr refcount_base(const refcount_base&) noexcept : _refcount(0) {}
+        constexpr void operator=(const refcount_base&) const noexcept {}
 
         constexpr int add_ref() const noexcept {
             return ++_refcount;
@@ -230,18 +224,21 @@ namespace intercept::types {
             return rcount;
         }
         void destruct() const noexcept {
-            delete const_cast<refcount *>(this);
+            delete const_cast<refcount*>(this);
         }
         virtual void lastRefDeleted() const { destruct(); }
+
     private:
         virtual int __dummy_refcount_func() const noexcept { return 0; }
     };
     class game_value_static;
-    template<class Type>
+    template <class Type>
     class ref {
-        friend class game_value_static; //Overrides _ref to nullptr in destructor when Arma is exiting
+        friend class game_value_static;  //Overrides _ref to nullptr in destructor when Arma is exiting
+        friend class ref;
         static_assert(std::is_base_of<refcount_base, Type>::value, "Type must inherit refcount_base");
-        Type* _ref{ nullptr };
+        Type* _ref{nullptr};
+
     public:
         using baseType = Type;
 
@@ -254,30 +251,51 @@ namespace intercept::types {
             _ref = other_;
         }
         //Copy from pointer
-        ref &operator = (Type *source_) noexcept {
-            Type *old = _ref;
+        ref& operator=(Type* source_) noexcept {
+            Type* old = _ref;
             if (source_) source_->add_ref();
             _ref = source_;
-            if (old) old->release();//decrement reference and delete object if refcount == 0
+            if (old) old->release();  //decrement reference and delete object if refcount == 0
             return *this;
         }
 
         //Construct from reference
-        constexpr ref(const ref &source_ref_) noexcept {
-            Type *source = source_ref_._ref;
+        constexpr ref(const ref& source_ref_) noexcept {
+            Type* source = source_ref_._ref;
             if (source) source->add_ref();
             _ref = source;
         }
         //Copy from reference.
-        ref &operator = (const ref &other_) {
-            Type *source = other_._ref;
-            Type *old = _ref;
+        ref& operator=(const ref& other_) {
+            Type* source = other_._ref;
+            Type* old = _ref;
             if (source) source->add_ref();
             _ref = source;
-            if (old) old->release();//decrement reference and delete object if refcount == 0
+            if (old) old->release();  //decrement reference and delete object if refcount == 0
             return *this;
         }
-        void swap(ref &other_) noexcept {
+
+        //Construct from reference and convert
+        template <typename T>
+        constexpr ref(const ref<T>& source_ref_) noexcept {
+            static_assert(std::is_constructible_v<T*, Type*>, "Cannot convert intercept::types::ref to incompatible type");
+            T* source = source_ref_._ref;
+            if (source) source->add_ref();
+            _ref = static_cast<Type*>(source);
+        }
+        //Copy from reference.
+        template <class T>
+        ref& operator=(const ref<T>& other_) {
+            static_assert(std::is_constructible_v<T*, Type*>, "Cannot convert intercept::types::ref to incompatible type");
+            T* source = other_._ref;
+            Type* old = _ref;
+            if (source) source->add_ref();
+            _ref = source;
+            if (old) old->release();  //decrement reference and delete object if refcount == 0
+            return *this;
+        }
+
+        void swap(ref& other_) noexcept {
             auto temp = other_._ref;
             other_._ref = _ref;
             _ref = temp;
@@ -290,12 +308,12 @@ namespace intercept::types {
         }
         //This returns a pointer to the underlying object. Use with caution!
 
-        [[deprecated]] constexpr Type *getRef() const noexcept { return _ref; }
+        [[deprecated]] constexpr Type* getRef() const noexcept { return _ref; }
         ///This returns a pointer to the underlying object. Use with caution!
-        constexpr Type *get() const noexcept { return _ref; }
-        constexpr Type *operator -> () const noexcept { return _ref; }
-        operator Type *() const noexcept { return _ref; }
-        bool operator != (const ref<Type>& other_) const noexcept { return _ref != other_._ref; }
+        constexpr Type* get() const noexcept { return _ref; }
+        constexpr Type* operator->() const noexcept { return _ref; }
+        operator Type*() const noexcept { return _ref; }
+        bool operator!=(const ref<Type>& other_) const noexcept { return _ref != other_._ref; }
         size_t ref_count() const noexcept { return _ref ? _ref->ref_count() : 0; }
     };
 
@@ -303,6 +321,7 @@ namespace intercept::types {
     template <class Type>
     class i_ref {
         Type* _ref{nullptr};
+
     public:
         using baseType = Type;
         constexpr i_ref() noexcept = default;
@@ -360,10 +379,11 @@ namespace intercept::types {
     };
 
     ///When this goes out of scope. The pointer is deleted. This takes ownership of the pointer
-    template<class Type>
+    template <class Type>
     class unique_ref {
     protected:
         Type* _ref;
+
     public:
         unique_ref() { _ref = NULL; }
         unique_ref(Type* source) {
@@ -371,33 +391,34 @@ namespace intercept::types {
         }
         unique_ref(const unique_ref& other) {
             _ref = other._ref;
-            other._ref = nullptr;//We take ownership
+            other._ref = nullptr;  //We take ownership
         }
         ~unique_ref() { clear(); }
 
-        unique_ref& operator = (Type* other) {
+        unique_ref& operator=(Type* other) {
             if (_ref == other) return *this;
             clear();
             _ref = other;
             return *this;
         }
 
-        unique_ref& operator = (const unique_ref& other) {
+        unique_ref& operator=(const unique_ref& other) {
             if (other._ref == _ref) return *this;
             clear();
             _ref = other._ref;
-            other._ref = nullptr;//We take ownership
+            other._ref = nullptr;  //We take ownership
             return *this;
         }
 
         bool is_null() const { return _ref == nullptr; }
-        void clear() { if (_ref) delete _ref; _ref = nullptr; }
-        Type* operator -> () const { return _ref; }
-        operator Type* () const { return _ref; }
-        Type *get() const { return _ref; }
+        void clear() {
+            if (_ref) delete _ref;
+            _ref = nullptr;
+        }
+        Type* operator->() const { return _ref; }
+        operator Type*() const { return _ref; }
+        Type* get() const { return _ref; }
     };
-
-
 
 #pragma endregion
 
@@ -406,7 +427,7 @@ namespace intercept::types {
     */
     class __vtable {
     public:
-        uintptr_t _vtable{ 0 };
+        uintptr_t _vtable{0};
     };
 
     class dummy_vtable_class {
@@ -417,99 +438,160 @@ namespace intercept::types {
     class _refcount_vtable_dummy : public __vtable, public refcount_base {};
 
 #pragma region Containers
-    template<class Type, class Allocator = rv_allocator<char>> //Has to be allocator of type char
+    template <class Type, class Allocator = rv_allocator<char>>  //Has to be allocator of type char
     class compact_array : public refcount_base {
         //static_assert(std::is_literal_type<Type>::value, "Type must be a literal type");
     public:
-
         class const_iterator;
 
         class iterator {
             friend class const_iterator;
             Type* p_;
+
         public:
             using iterator_category = std::random_access_iterator_tag;
             using value_type = Type;
             using difference_type = ptrdiff_t;
-            using pointer = Type * ;
-            using reference = Type & ;
+            using pointer = Type*;
+            using reference = Type&;
             using _Unchecked_type = pointer;
 
             iterator() : p_(nullptr) {}
             explicit iterator(Type* p) : p_(p) {}
             iterator(const iterator& other) : p_(other.p_) {}
-            iterator& operator=(const iterator& other) { p_ = other.p_; return *this; }
+            iterator& operator=(const iterator& other) {
+                p_ = other.p_;
+                return *this;
+            }
 
-            iterator& operator++() { ++p_; return *this; } // prefix++
-            iterator  operator++(int) { iterator tmp(*this); ++(*this); return tmp; } // postfix++
-            iterator& operator--() { --p_; return *this; } // prefix--
-            iterator  operator--(int) { iterator tmp(*this); --(*this); return tmp; } // postfix--
+            iterator& operator++() {
+                ++p_;
+                return *this;
+            }  // prefix++
+            iterator operator++(int) {
+                iterator tmp(*this);
+                ++(*this);
+                return tmp;
+            }  // postfix++
+            iterator& operator--() {
+                --p_;
+                return *this;
+            }  // prefix--
+            iterator operator--(int) {
+                iterator tmp(*this);
+                --(*this);
+                return tmp;
+            }  // postfix--
 
-            void     operator+=(const std::size_t& n) { p_ += n; }
-            void     operator+=(const iterator& other) { p_ += other.p_; }
-            iterator operator+ (const std::size_t& n) const { iterator tmp(*this); tmp += n; return tmp; }
-            iterator operator+ (const iterator& other) const { iterator tmp(*this); tmp += other; return tmp; }
+            void operator+=(const std::size_t& n) { p_ += n; }
+            void operator+=(const iterator& other) { p_ += other.p_; }
+            iterator operator+(const std::size_t& n) const {
+                iterator tmp(*this);
+                tmp += n;
+                return tmp;
+            }
+            iterator operator+(const iterator& other) const {
+                iterator tmp(*this);
+                tmp += other;
+                return tmp;
+            }
 
-            void        operator-=(const std::size_t& n) { p_ -= n; }
-            void        operator-=(const iterator& other) { p_ -= other.p_; }
-            iterator    operator- (const std::size_t& n) const { iterator tmp(*this); tmp -= n; return tmp; }
-            std::size_t operator- (const iterator& other) const { return p_ - other.p_; }
+            void operator-=(const std::size_t& n) { p_ -= n; }
+            void operator-=(const iterator& other) { p_ -= other.p_; }
+            iterator operator-(const std::size_t& n) const {
+                iterator tmp(*this);
+                tmp -= n;
+                return tmp;
+            }
+            std::size_t operator-(const iterator& other) const { return p_ - other.p_; }
 
-            bool operator< (const iterator& other) const { return (p_ - other.p_) < 0; }
+            bool operator<(const iterator& other) const { return (p_ - other.p_) < 0; }
             bool operator<=(const iterator& other) const { return (p_ - other.p_) <= 0; }
-            bool operator> (const iterator& other) const { return (p_ - other.p_) > 0; }
+            bool operator>(const iterator& other) const { return (p_ - other.p_) > 0; }
             bool operator>=(const iterator& other) const { return (p_ - other.p_) >= 0; }
-            bool operator==(const iterator& other) const { return  p_ == other.p_; }
-            bool operator!=(const iterator& other) const { return  p_ != other.p_; }
+            bool operator==(const iterator& other) const { return p_ == other.p_; }
+            bool operator!=(const iterator& other) const { return p_ != other.p_; }
 
             Type& operator*() const { return *p_; }
-            Type* operator->() { return  p_; }
+            Type* operator->() { return p_; }
             explicit operator Type*() { return p_; }
         };
         class const_iterator {
             const Type* p_;
+
         public:
             using iterator_category = std::random_access_iterator_tag;
             using value_type = Type;
             using difference_type = ptrdiff_t;
-            using pointer = Type * ;
-            using reference = Type & ;
+            using pointer = Type*;
+            using reference = Type&;
             using _Unchecked_type = pointer;
 
             const_iterator() : p_(nullptr) {}
             explicit const_iterator(const Type* p) noexcept : p_(p) {}
             const_iterator(const typename compact_array<Type>::iterator& other) : p_(other.p_) {}
             const_iterator(const const_iterator& other) noexcept : p_(other.p_) {}
-            const_iterator& operator=(const const_iterator& other) { p_ = other.p_; return *this; }
-            const_iterator& operator=(const typename compact_array<Type>::iterator& other) { p_ = other.p_; return *this; }
+            const_iterator& operator=(const const_iterator& other) {
+                p_ = other.p_;
+                return *this;
+            }
+            const_iterator& operator=(const typename compact_array<Type>::iterator& other) {
+                p_ = other.p_;
+                return *this;
+            }
 
-            const_iterator& operator++() noexcept { ++p_; return *this; } // prefix++
-            const_iterator  operator++(int) { const_iterator tmp(*this); ++(*this); return tmp; } // postfix++
-            const_iterator& operator--() noexcept { --p_; return *this; } // prefix--
-            const_iterator  operator--(int) { const_iterator tmp(*this); --(*this); return tmp; } // postfix--
+            const_iterator& operator++() noexcept {
+                ++p_;
+                return *this;
+            }  // prefix++
+            const_iterator operator++(int) {
+                const_iterator tmp(*this);
+                ++(*this);
+                return tmp;
+            }  // postfix++
+            const_iterator& operator--() noexcept {
+                --p_;
+                return *this;
+            }  // prefix--
+            const_iterator operator--(int) {
+                const_iterator tmp(*this);
+                --(*this);
+                return tmp;
+            }  // postfix--
 
-            void           operator+=(const std::size_t& n) { p_ += n; }
-            void           operator+=(const const_iterator& other) { p_ += other.p_; }
-            const_iterator operator+ (const std::size_t& n)        const { const_iterator tmp(*this); tmp += n; return tmp; }
-            const_iterator operator+ (const const_iterator& other) const { const_iterator tmp(*this); tmp += other; return tmp; }
+            void operator+=(const std::size_t& n) { p_ += n; }
+            void operator+=(const const_iterator& other) { p_ += other.p_; }
+            const_iterator operator+(const std::size_t& n) const {
+                const_iterator tmp(*this);
+                tmp += n;
+                return tmp;
+            }
+            const_iterator operator+(const const_iterator& other) const {
+                const_iterator tmp(*this);
+                tmp += other;
+                return tmp;
+            }
 
-            void           operator-=(const std::size_t& n) noexcept { p_ -= n; }
-            void           operator-=(const const_iterator& other) noexcept { p_ -= other.p_; }
-            const_iterator operator- (const std::size_t& n)        const { const_iterator tmp(*this); tmp -= n; return tmp; }
-            std::size_t    operator- (const const_iterator& other) const noexcept { return p_ - other.p_; }
+            void operator-=(const std::size_t& n) noexcept { p_ -= n; }
+            void operator-=(const const_iterator& other) noexcept { p_ -= other.p_; }
+            const_iterator operator-(const std::size_t& n) const {
+                const_iterator tmp(*this);
+                tmp -= n;
+                return tmp;
+            }
+            std::size_t operator-(const const_iterator& other) const noexcept { return p_ - other.p_; }
 
-            bool operator< (const const_iterator& other) const noexcept { return (p_ - other.p_) < 0; }
+            bool operator<(const const_iterator& other) const noexcept { return (p_ - other.p_) < 0; }
             bool operator<=(const const_iterator& other) const noexcept { return (p_ - other.p_) <= 0; }
-            bool operator> (const const_iterator& other) const noexcept { return (p_ - other.p_) > 0; }
+            bool operator>(const const_iterator& other) const noexcept { return (p_ - other.p_) > 0; }
             bool operator>=(const const_iterator& other) const noexcept { return (p_ - other.p_) >= 0; }
-            bool operator==(const const_iterator& other) const noexcept { return  p_ == other.p_; }
-            bool operator!=(const const_iterator& other) const noexcept { return  p_ != other.p_; }
+            bool operator==(const const_iterator& other) const noexcept { return p_ == other.p_; }
+            bool operator!=(const const_iterator& other) const noexcept { return p_ != other.p_; }
 
-            const Type& operator*()  const noexcept { return *p_; }
-            const Type* operator->() const noexcept { return  p_; }
+            const Type& operator*() const noexcept { return *p_; }
+            const Type* operator->() const noexcept { return p_; }
             explicit operator const Type*() const noexcept { return p_; }
         };
-
 
         size_t size() const noexcept { return _size; }
         Type* data() noexcept { return &_data; }
@@ -537,21 +619,21 @@ namespace intercept::types {
 
         //Doesn't clear memory. use create_zero if you want that
         static compact_array* create(size_t number_of_elements_) {
-            const size_t size = sizeof(compact_array) + sizeof(Type)*(number_of_elements_ - 1);//-1 because we already have one element in compact_array
+            const size_t size = sizeof(compact_array) + sizeof(Type) * (number_of_elements_ - 1);  //-1 because we already have one element in compact_array
             auto* buffer = reinterpret_cast<compact_array*>(Allocator::allocate(size));
-        #pragma warning(suppress: 26409) //don't use new/delete
+#pragma warning(suppress : 26409)  //don't use new/delete
             new (buffer) compact_array(number_of_elements_);
             return buffer;
         }
         static compact_array* create_zero(size_t number_of_elements_) {
-            const size_t size = sizeof(compact_array) + sizeof(Type)*(number_of_elements_ - 1);//-1 because we already have one element in compact_array
+            const size_t size = sizeof(compact_array) + sizeof(Type) * (number_of_elements_ - 1);  //-1 because we already have one element in compact_array
             auto* buffer = reinterpret_cast<compact_array*>(Allocator::allocate(size));
-        #pragma warning(suppress: 26409) //don't use new/delete
+#pragma warning(suppress : 26409)  //don't use new/delete
             std::memset(buffer, 0, size);
             new (buffer) compact_array(number_of_elements_);
             return buffer;
         }
-        static compact_array* create(const compact_array &other) {
+        static compact_array* create(const compact_array& other) {
             const size_t size = other.size();
             auto* buffer = reinterpret_cast<compact_array*>(Allocator::allocate(size));
             new (buffer) compact_array(size);
@@ -559,12 +641,12 @@ namespace intercept::types {
             return buffer;
         }
 
-        template<class _InIt>
+        template <class _InIt>
         static compact_array* create(_InIt beg, _InIt end) {
-            const size_t size = sizeof(compact_array) + sizeof(Type)*(std::distance(beg,end)-1);
+            const size_t size = sizeof(compact_array) + sizeof(Type) * (std::distance(beg, end) - 1);
             auto* buffer = reinterpret_cast<compact_array*>(Allocator::allocate(size));
             std::memset(buffer, 0, size);
-        #pragma warning(suppress: 26409) //don't use new/delete
+#pragma warning(suppress : 26409)  //don't use new/delete
             new (buffer) compact_array(size);
 
             size_t index = 0;
@@ -576,9 +658,9 @@ namespace intercept::types {
         }
 
         //Specialty function to copy less elements or to allocate more space
-        static compact_array* create(const compact_array &other, size_t element_count) {
+        static compact_array* create(const compact_array& other, size_t element_count) {
             const size_t size = other.size();
-            auto buffer = reinterpret_cast<compact_array*>(Allocator::allocate(sizeof(compact_array) + sizeof(Type)*(element_count - 1)));
+            auto buffer = reinterpret_cast<compact_array*>(Allocator::allocate(sizeof(compact_array) + sizeof(Type) * (element_count - 1)));
             new (buffer) compact_array(element_count);
             std::memset(buffer->data(), 0, element_count * sizeof(Type));
             const auto elements_to_copy = std::min(size, element_count);
@@ -590,19 +672,19 @@ namespace intercept::types {
         void del() const {
             this->~compact_array();
             const void* _thisptr = this;
-        #pragma warning(suppress: 26492) //don't cast away const
+#pragma warning(suppress : 26492)  //don't cast away const
             const auto _thisptr2 = const_cast<void*>(_thisptr);
             Allocator::deallocate(static_cast<char*>(_thisptr2), _size - 1 + sizeof(compact_array));
         }
 
         size_t _size;
         Type _data{};
+
     private:
         explicit compact_array(const size_t size_) noexcept {
             _size = size_;
         }
     };
-
 
     //template<std::size_t N>
     //class r_string_const : public refcount_base { // constexpr string
@@ -631,16 +713,16 @@ namespace intercept::types {
             _ref = copy_._ref;
         }
 
-        r_string& operator = (r_string&& move_) noexcept {
+        r_string& operator=(r_string&& move_) noexcept {
             if (this == &move_)
                 return *this;
             _ref.swap(move_._ref);
             return *this;
         }
 
-        r_string& operator = (const r_string& copy_) = default;
+        r_string& operator=(const r_string& copy_) = default;
 
-        r_string& operator = (std::string_view copy_) {
+        r_string& operator=(std::string_view copy_) {
             _ref = create(copy_.data(), copy_.length());
             return *this;
         }
@@ -651,11 +733,11 @@ namespace intercept::types {
         const char* c_str() const noexcept { return data(); }
         //This will copy the underlying container if we cannot safely modify this r_string
         void make_mutable() {
-            if (_ref && _ref->ref_count() > 1) {//If there is only one reference we can safely modify the string
+            if (_ref && _ref->ref_count() > 1) {  //If there is only one reference we can safely modify the string
                 _ref = create(_ref->data());
             }
         }
-        explicit operator const char *() const noexcept { return data(); }
+        explicit operator const char*() const noexcept { return data(); }
         operator std::string_view() const noexcept { return std::string_view(data()); }
         //explicit operator std::string() const { return std::string(data()); } //non explicit will break string_view operator because std::string operator because it becomes ambiguous
         ///This calls strlen so O(N)
@@ -680,66 +762,66 @@ namespace intercept::types {
         }
 
         ///== is case insensitive just like scripting
-        bool operator == (const char *other_) const {
-            if (!data())  return !other_ || !*other_; //empty?
+        bool operator==(const char* other_) const {
+            if (!data()) return !other_ || !*other_;  //empty?
 
             return std::equal(_ref->cbegin(), _ref->cend(),
-                compact_array<char>::const_iterator(other_), [](unsigned char l, unsigned char r) {return l == r || tolower(l) == tolower(r); });
+                              compact_array<char>::const_iterator(other_), [](unsigned char l, unsigned char r) { return l == r || tolower(l) == tolower(r); });
         }
 
         ///== is case insensitive just like scripting
-        bool operator == (std::string_view other_) const {
-            if (!data()) return other_.empty(); //empty?
-            if (other_.length() > _ref->size()) return false; //There is more data than we can even have
+        bool operator==(std::string_view other_) const {
+            if (!data()) return other_.empty();                //empty?
+            if (other_.length() > _ref->size()) return false;  //There is more data than we can even have
 
             return std::equal(other_.cbegin(), other_.cend(),
-                _ref->cbegin(), [](unsigned char l, unsigned char r) {return l == r || tolower(l) == tolower(r); });
+                              _ref->cbegin(), [](unsigned char l, unsigned char r) { return l == r || tolower(l) == tolower(r); });
         }
 
         ///== is case insensitive just like scripting
-        bool operator == (const r_string& other_) const {
-            if (!data()) return !other_.data() || !*other_.data(); //empty?
+        bool operator==(const r_string& other_) const {
+            if (!data()) return !other_.data() || !*other_.data();  //empty?
             if (data() == other_.data()) return true;
 
             return operator==(std::string_view(other_));
         }
 
         ///== is case insensitive just like scripting
-        bool operator == (const std::string& other_) const {
+        bool operator==(const std::string& other_) const {
             return operator==(std::string_view(other_));
         }
 
         ///!= is case insensitive just like scripting
-        bool operator != (const r_string& other_) const {
+        bool operator!=(const r_string& other_) const {
             return !(*this == other_);
         }
 
         ///!= is case insensitive just like scripting
-        bool operator != (const std::string& other_) const {
+        bool operator!=(const std::string& other_) const {
             return !(*this == other_);
         }
 
         ///!= is case insensitive just like scripting
-        bool operator != (const std::string_view other_) const {//#TODO templates would be nice here. But we don't want string_view by reference
+        bool operator!=(const std::string_view other_) const {  //#TODO templates would be nice here. But we don't want string_view by reference
             return !(*this == other_);
         }
 
-        bool operator < (const r_string& other_) const {
-            if (!data()) return false; //empty?
+        bool operator<(const r_string& other_) const {
+            if (!data()) return false;  //empty?
             return strcmp(data(), other_.data()) < 0;
         }
 
-        bool operator > (const r_string& other_) const {
-            if (!data()) return false; //empty?
+        bool operator>(const r_string& other_) const {
+            if (!data()) return false;  //empty?
             return strcmp(data(), other_.data()) > 0;
         }
 
-        friend std::ostream& operator << (std::ostream& _os, const r_string& _s) {
+        friend std::ostream& operator<<(std::ostream& _os, const r_string& _s) {
             _os << _s.data();
             return _os;
         }
 
-        friend std::istream& operator >> (std::istream& _in, r_string& _t) {
+        friend std::istream& operator>>(std::istream& _in, r_string& _t) {
             char inp;
             std::string tmp;
             while (_in.get(inp)) {
@@ -750,32 +832,32 @@ namespace intercept::types {
             return _in;
         }
 
-        bool compare_case_sensitive(const char *other_) const {
+        bool compare_case_sensitive(const char* other_) const {
             return !std::equal(_ref->cbegin(), _ref->cend(),
-                compact_array<char>::const_iterator(other_), [](unsigned char l, unsigned char r) {return l == r; });
+                               compact_array<char>::const_iterator(other_), [](unsigned char l, unsigned char r) { return l == r; });
         }
 
-        bool compare_case_insensitive(const char *other_) const {//#TODO string_view variant with length checking
+        bool compare_case_insensitive(const char* other_) const {  //#TODO string_view variant with length checking
             return !std::equal(_ref->cbegin(), _ref->cend(),
-                compact_array<char>::const_iterator(other_), [](unsigned char l, unsigned char r) {return ::tolower(l) == ::tolower(r); });
+                               compact_array<char>::const_iterator(other_), [](unsigned char l, unsigned char r) { return ::tolower(l) == ::tolower(r); });
         }
 
         std::string_view substr(size_t offset, size_t length) const {
             if (_ref)
                 return std::string_view(data() + offset, std::min(length, size()));
             return std::string_view();
-        } 
+        }
 
         size_t find(const char ch_, const size_t start_ = 0) const {
             if (length() == 0) return -1;
-            const char *pos = strchr(_ref->data() + start_, ch_);
+            const char* pos = strchr(_ref->data() + start_, ch_);
             if (pos == nullptr) return -1;
             return pos - _ref->data();
         }
 
-        size_t find(const char *substring_, const size_t start_ = 0) const {
+        size_t find(const char* substring_, const size_t start_ = 0) const {
             if (_ref == nullptr || length() == 0) return -1;
-            const char *pos = strstr(_ref->data() + start_, substring_);
+            const char* pos = strstr(_ref->data() + start_, substring_);
             if (pos == nullptr) return -1;
             return pos - _ref->data();
         }
@@ -788,7 +870,7 @@ namespace intercept::types {
 
         r_string append(std::string_view right_) const {
             const auto my_length = length();
-            auto new_data = create(my_length + right_.length() + 1);//Space for terminating nullchar
+            auto new_data = create(my_length + right_.length() + 1);  //Space for terminating nullchar
 
             std::copy_n(begin(), my_length, new_data->begin());
             std::copy_n(right_.data(), right_.length(), new_data->begin() + my_length);
@@ -798,8 +880,8 @@ namespace intercept::types {
         }
         r_string& append_modify(std::string_view right_) {
             const auto my_length = length();
-            auto newData = create(my_length + right_.length() + 1);//Space for terminating nullchar
-            
+            auto newData = create(my_length + right_.length() + 1);  //Space for terminating nullchar
+
             std::copy_n(data(), my_length, newData->begin());
             std::copy_n(right_.data(), right_.length(), newData->begin() + my_length);
 
@@ -839,31 +921,29 @@ namespace intercept::types {
             return '\0';
         }
 
-
-
     private:
         ref<compact_array<char>> _ref;
 
-        static compact_array<char> *create(const char *str, const size_t len_) {
+        static compact_array<char>* create(const char* str, const size_t len_) {
             if (len_ == 0 || *str == 0) return nullptr;
-            compact_array<char> *string = compact_array<char>::create(len_ + 1);
-        #if __GNUC__
+            compact_array<char>* string = compact_array<char>::create(len_ + 1);
+#if __GNUC__
             std::copy_n(str, len_, string->data());
-        #else
-            strncpy_s(string->data(), string->size(), str, len_);//#TODO better use memcpy? does strncpy_s check for null chars? we don't want that
-        #endif
+#else
+            strncpy_s(string->data(), string->size(), str, len_);  //#TODO better use memcpy? does strncpy_s check for null chars? we don't want that
+#endif
             string->data()[len_] = 0;
             return string;
         }
 
-        static compact_array<char> *create(const size_t len_) {
+        static compact_array<char>* create(const size_t len_) {
             if (len_ == 0) return nullptr;
-            compact_array<char> *string = compact_array<char>::create(len_ + 1);
+            compact_array<char>* string = compact_array<char>::create(len_ + 1);
             string->data()[0] = 0;
             return string;
         }
 
-        static compact_array<char> *create(const char *str_) {
+        static compact_array<char>* create(const char* str_) {
             if (*str_ == 0) return nullptr;
             return create(str_, strlen(str_));
         }
@@ -876,24 +956,26 @@ namespace intercept::types {
         //        return literal; \
         //    }())
 
-//constexpr const r_string& operator ""_rs(const char* __str, size_t len) {
-//    return r_string_literal(__str);
-//};
+    //constexpr const r_string& operator ""_rs(const char* __str, size_t len) {
+    //    return r_string_literal(__str);
+    //};
 
-//Contributed by ArmaDebugEngine
+    //Contributed by ArmaDebugEngine
     class rv_arraytype {};
 
-    template<class Type>
+    template <class Type>
     class rv_array : public rv_arraytype {
     protected:
-        Type *_data;
+        Type* _data;
         int _n;
+
     public:
         class const_iterator;
 
         class iterator {
             friend class const_iterator;
             Type* p_;
+
         public:
             using iterator_category = std::random_access_iterator_tag;
             using value_type = Type;
@@ -904,96 +986,166 @@ namespace intercept::types {
             iterator() : p_(nullptr) {}
             explicit iterator(Type* p) : p_(p) {}
             iterator(const iterator& other) : p_(other.p_) {}
-            iterator& operator=(const iterator& other) { p_ = other.p_; return *this; }
+            iterator& operator=(const iterator& other) {
+                p_ = other.p_;
+                return *this;
+            }
 
-            iterator& operator++() { ++p_; return *this; } // prefix++
-            iterator  operator++(int) { iterator tmp(*this); ++(*this); return tmp; } // postfix++
-            iterator& operator--() { --p_; return *this; } // prefix--
-            iterator  operator--(int) { iterator tmp(*this); --(*this); return tmp; } // postfix--
+            iterator& operator++() {
+                ++p_;
+                return *this;
+            }  // prefix++
+            iterator operator++(int) {
+                iterator tmp(*this);
+                ++(*this);
+                return tmp;
+            }  // postfix++
+            iterator& operator--() {
+                --p_;
+                return *this;
+            }  // prefix--
+            iterator operator--(int) {
+                iterator tmp(*this);
+                --(*this);
+                return tmp;
+            }  // postfix--
 
-            void     operator+=(const std::size_t& n) { p_ += n; }
-            void     operator+=(const iterator& other) { p_ += other.p_; }
-            iterator operator+ (const std::size_t& n) const { iterator tmp(*this); tmp += n; return tmp; }
-            iterator operator+ (const iterator& other) const { iterator tmp(*this); tmp += other; return tmp; }
+            void operator+=(const std::size_t& n) { p_ += n; }
+            void operator+=(const iterator& other) { p_ += other.p_; }
+            iterator operator+(const std::size_t& n) const {
+                iterator tmp(*this);
+                tmp += n;
+                return tmp;
+            }
+            iterator operator+(const iterator& other) const {
+                iterator tmp(*this);
+                tmp += other;
+                return tmp;
+            }
 
-            void        operator-=(const std::size_t& n) { p_ -= n; }
-            void        operator-=(const iterator& other) { p_ -= other.p_; }
-            iterator    operator- (const std::size_t& n) const { iterator tmp(*this); tmp -= n; return tmp; }
-            std::size_t operator- (const iterator& other) const { return p_ - other.p_; }
+            void operator-=(const std::size_t& n) { p_ -= n; }
+            void operator-=(const iterator& other) { p_ -= other.p_; }
+            iterator operator-(const std::size_t& n) const {
+                iterator tmp(*this);
+                tmp -= n;
+                return tmp;
+            }
+            std::size_t operator-(const iterator& other) const { return p_ - other.p_; }
 
-            bool operator< (const iterator& other) const { return (p_ - other.p_) < 0; }
+            bool operator<(const iterator& other) const { return (p_ - other.p_) < 0; }
             bool operator<=(const iterator& other) const { return (p_ - other.p_) <= 0; }
-            bool operator> (const iterator& other) const { return (p_ - other.p_) > 0; }
+            bool operator>(const iterator& other) const { return (p_ - other.p_) > 0; }
             bool operator>=(const iterator& other) const { return (p_ - other.p_) >= 0; }
-            bool operator==(const iterator& other) const { return  p_ == other.p_; }
-            bool operator!=(const iterator& other) const { return  p_ != other.p_; }
+            bool operator==(const iterator& other) const { return p_ == other.p_; }
+            bool operator!=(const iterator& other) const { return p_ != other.p_; }
 
             Type& operator*() const { return *p_; }
-            Type* operator->() { return  p_; }
+            Type* operator->() { return p_; }
             explicit operator Type*() { return p_; }
         };
         class const_iterator {
             const Type* p_;
+
         public:
             using iterator_category = std::random_access_iterator_tag;
             using value_type = Type;
             using difference_type = ptrdiff_t;
-            using pointer = Type *;
-            using reference = Type &;
+            using pointer = Type*;
+            using reference = Type&;
 
             const_iterator() : p_(nullptr) {}
             explicit const_iterator(const Type* p) noexcept : p_(p) {}
             const_iterator(const typename rv_array<Type>::iterator& other) : p_(other.p_) {}
             const_iterator(const const_iterator& other) noexcept : p_(other.p_) {}
-            const_iterator& operator=(const const_iterator& other) { p_ = other.p_; return other; }
-            const_iterator& operator=(const typename rv_array<Type>::iterator& other) { p_ = other.p_; return other; }
+            const_iterator& operator=(const const_iterator& other) {
+                p_ = other.p_;
+                return other;
+            }
+            const_iterator& operator=(const typename rv_array<Type>::iterator& other) {
+                p_ = other.p_;
+                return other;
+            }
 
-            const_iterator& operator++() noexcept { ++p_; return *this; } // prefix++
-            const_iterator  operator++(int) { const_iterator tmp(*this); ++(*this); return tmp; } // postfix++
-            const_iterator& operator--() noexcept { --p_; return *this; } // prefix--
-            const_iterator  operator--(int) { const_iterator tmp(*this); --(*this); return tmp; } // postfix--
+            const_iterator& operator++() noexcept {
+                ++p_;
+                return *this;
+            }  // prefix++
+            const_iterator operator++(int) {
+                const_iterator tmp(*this);
+                ++(*this);
+                return tmp;
+            }  // postfix++
+            const_iterator& operator--() noexcept {
+                --p_;
+                return *this;
+            }  // prefix--
+            const_iterator operator--(int) {
+                const_iterator tmp(*this);
+                --(*this);
+                return tmp;
+            }  // postfix--
 
-            void           operator+=(const std::size_t& n) { p_ += n; }
-            void           operator+=(const const_iterator& other) { p_ += other.p_; }
-            const_iterator operator+ (const std::size_t& n)        const { const_iterator tmp(*this); tmp += n; return tmp; }
-            const_iterator operator+ (const const_iterator& other) const { const_iterator tmp(*this); tmp += other; return tmp; }
+            void operator+=(const std::size_t& n) { p_ += n; }
+            void operator+=(const const_iterator& other) { p_ += other.p_; }
+            const_iterator operator+(const std::size_t& n) const {
+                const_iterator tmp(*this);
+                tmp += n;
+                return tmp;
+            }
+            const_iterator operator+(const const_iterator& other) const {
+                const_iterator tmp(*this);
+                tmp += other;
+                return tmp;
+            }
 
-            void           operator-=(const std::size_t& n) noexcept { p_ -= n; }
-            void           operator-=(const const_iterator& other) noexcept { p_ -= other.p_; }
-            const_iterator operator- (const std::size_t& n)        const { const_iterator tmp(*this); tmp -= n; return tmp; }
-            std::size_t    operator- (const const_iterator& other) const noexcept { return p_ - other.p_; }
+            void operator-=(const std::size_t& n) noexcept { p_ -= n; }
+            void operator-=(const const_iterator& other) noexcept { p_ -= other.p_; }
+            const_iterator operator-(const std::size_t& n) const {
+                const_iterator tmp(*this);
+                tmp -= n;
+                return tmp;
+            }
+            std::size_t operator-(const const_iterator& other) const noexcept { return p_ - other.p_; }
 
-            bool operator< (const const_iterator& other) const noexcept { return (p_ - other.p_) < 0; }
+            bool operator<(const const_iterator& other) const noexcept { return (p_ - other.p_) < 0; }
             bool operator<=(const const_iterator& other) const noexcept { return (p_ - other.p_) <= 0; }
-            bool operator> (const const_iterator& other) const noexcept { return (p_ - other.p_) > 0; }
+            bool operator>(const const_iterator& other) const noexcept { return (p_ - other.p_) > 0; }
             bool operator>=(const const_iterator& other) const noexcept { return (p_ - other.p_) >= 0; }
-            bool operator==(const const_iterator& other) const noexcept { return  p_ == other.p_; }
-            bool operator!=(const const_iterator& other) const noexcept { return  p_ != other.p_; }
+            bool operator==(const const_iterator& other) const noexcept { return p_ == other.p_; }
+            bool operator!=(const const_iterator& other) const noexcept { return p_ != other.p_; }
 
-            const Type& operator*()  const noexcept { return *p_; }
-            const Type* operator->() const noexcept { return  p_; }
+            const Type& operator*() const noexcept { return *p_; }
+            const Type* operator->() const noexcept { return p_; }
             explicit operator const Type*() const noexcept { return p_; }
         };
 
-
-        constexpr rv_array() noexcept :_data(nullptr), _n(0) {}
-        rv_array(rv_array<Type>&& move_) noexcept :_data(move_._data), _n(move_._n) { move_._data = nullptr; move_._n = 0; }
-        Type &get(const size_t i_) {
+        constexpr rv_array() noexcept : _data(nullptr), _n(0) {}
+        rv_array(rv_array<Type>&& move_) noexcept : _data(move_._data), _n(move_._n) {
+            move_._data = nullptr;
+            move_._n = 0;
+        }
+        Type& get(const size_t i_) {
             if (i_ > count()) throw std::out_of_range("rv_array access out of range");
             return _data[i_];
         }
-        const Type &get(const size_t i_) const {
+        const Type& get(const size_t i_) const {
             if (i_ > count()) throw std::out_of_range("rv_array access out of range");
             return _data[i_];
         }
-        Type &operator [] (const size_t i_) { return get(i_); }
-        const Type &operator [] (const size_t i_) const { return get(i_); }
-        Type *data() { return _data; }
+        Type& operator[](const size_t i_) { return get(i_); }
+        const Type& operator[](const size_t i_) const { return get(i_); }
+        Type* data() { return _data; }
         constexpr size_t count() const noexcept { return static_cast<size_t>(_n); }
         constexpr size_t size() const noexcept { return static_cast<size_t>(_n); }
 
-        iterator begin() { if (!_data) return iterator(); return iterator(&get(0)); }
-        iterator end() { if (!_data) return iterator(); return iterator(&get(_n)); }
+        iterator begin() {
+            if (!_data) return iterator();
+            return iterator(&get(0));
+        }
+        iterator end() {
+            if (!_data) return iterator();
+            return iterator(&get(_n));
+        }
 
         const_iterator cbegin() const { return const_iterator(&get(0)); }
         const_iterator cend() const { return const_iterator(&get(_n)); }
@@ -1001,72 +1153,73 @@ namespace intercept::types {
         const_iterator begin() const { return const_iterator(&get(0)); }
         const_iterator end() const { return const_iterator(&get(_n)); }
 
-        const Type &front() const { return get(0); }
-        const Type &back() const { return get(_n - 1); }
+        const Type& front() const { return get(0); }
+        const Type& back() const { return get(_n - 1); }
 
-        Type &front() { return get(0); }
-        Type &back() { return get(_n - 1); }
+        Type& front() { return get(0); }
+        Type& back() { return get(_n - 1); }
 
         bool is_empty() const { return _n == 0; }
         bool empty() const { return _n == 0; }
 
         template <class Func>
-        void for_each(const Func &f_) const {
+        void for_each(const Func& f_) const {
             for (size_t i = 0; i < count(); i++) {
                 f_(get(i));
             }
         }
 
         template <class Func>
-        void for_each_backwards(const Func &f_) const { //This returns if Func returns true
+        void for_each_backwards(const Func& f_) const {  //This returns if Func returns true
             for (size_t i = count() - 1; i >= 0; i--) {
                 if (f_(get(i))) return;
             }
         }
 
         template <class Func>
-        void for_each(const Func &f_) {
+        void for_each(const Func& f_) {
             for (size_t i = 0; i < count(); i++) {
                 f_(get(i));
             }
         }
         size_t hash() const {
-            size_t _hash{ 0 };
+            size_t _hash{0};
             for (const auto& it : *this) {
                 _hash ^= std::hash<Type>()(it) + 0x9e3779b9 + (_hash << 6) + (_hash >> 2);
             }
             return _hash;
         }
-        template<typename FindType>
+        template <typename FindType>
         iterator find(const FindType& find_) {
             return std::find(begin(), end(), find_);
         }
     };
 
-    template<class Type, class Allocator = rv_allocator<Type>, size_t growthFactor = 32>
+    template <class Type, class Allocator = rv_allocator<Type>, size_t growthFactor = 32>
     class
-    #ifdef _MSC_VER
+#ifdef _MSC_VER
         __declspec(empty_bases)
-    #endif
+#endif
         //#TODO try GCC maybe __attribute__((__packed__)) or #pragma pack. But be careful of the bool in local alloc
-        auto_array : public rv_array<Type>, private Allocator {
+        auto_array : public rv_array<Type>,
+                     private Allocator {
         typedef rv_array<Type> base;
+
     protected:
         int _maxItems;
-        Type *try_realloc(Type *old_, size_t n_) {
-            Type *ret = Allocator::reallocate(old_, n_);
+        Type* try_realloc(Type* old_, size_t n_) {
+            Type* ret = Allocator::reallocate(old_, n_);
             return ret;
         }
 
         void reallocate(size_t size_) {
-
             if (_maxItems == size_) return;
 
             if (base::_n > static_cast<int>(size_)) {
                 resize(size_);
-                return;//resize calls reallocate and reallocates... Ugly.. I know
+                return;  //resize calls reallocate and reallocates... Ugly.. I know
             }
-            Type *newData = nullptr;
+            Type* newData = nullptr;
             if (base::_data && size_ > 0 && ((newData = try_realloc(base::_data, size_)))) {
                 //if (size > _maxItems)//Don't null out new stuff if there is no new stuff
                 //    std::fill(reinterpret_cast<uint32_t*>(&newData[_maxItems]), reinterpret_cast<uint32_t*>(&newData[size]), 0);
@@ -1077,42 +1230,42 @@ namespace intercept::types {
             newData = Allocator::create_uninitialized_array(size_);
             //memset(newData, 0, size * sizeof(Type));
             if (base::_data) {
-            #ifdef __GNUC__
+#ifdef __GNUC__
                 memmove(newData, base::_data, base::_n * sizeof(Type));
-            #else
+#else
                 //std::uninitialized_move(begin(), end(), newData); //This might be cleaner. But still causes a move construct call where memmove just moves bytes.
                 memmove_s(newData, size_ * sizeof(Type), base::_data, base::_n * sizeof(Type));
-            #endif
+#endif
                 Allocator::deallocate(base::_data);
             }
             base::_data = newData;
             _maxItems = static_cast<int>(size_);
-
         }
 
         void grow(const size_t n_) {
-        #undef max
+#undef max
             reallocate(_maxItems + std::max(n_, growthFactor));
         }
+
     public:
-        using base::end;
         using base::begin;
-        using base::cend;
         using base::cbegin;
+        using base::cend;
+        using base::end;
         using iterator = typename base::iterator;
         using const_iterator = typename base::const_iterator;
         constexpr auto_array() noexcept : rv_array<Type>(), _maxItems(0) {}
-        auto_array(const std::initializer_list<Type> &init_) : rv_array<Type>(), _maxItems(0) {
+        auto_array(const std::initializer_list<Type>& init_) : rv_array<Type>(), _maxItems(0) {
             insert(end(), init_.begin(), init_.end());
         }
-        template<class _InIt>
+        template <class _InIt>
         auto_array(_InIt first_, _InIt last_) : rv_array<Type>(), _maxItems(0) {
             insert(end(), first_, last_);
         }
-        auto_array(const auto_array<Type> &copy_) : rv_array<Type>(), _maxItems(0) {
+        auto_array(const auto_array<Type>& copy_) : rv_array<Type>(), _maxItems(0) {
             insert(end(), copy_.begin(), copy_.end());
         }
-        auto_array(auto_array<Type> &&move_) noexcept : rv_array<Type>(std::move(move_)), _maxItems(move_._maxItems) {
+        auto_array(auto_array<Type>&& move_) noexcept : rv_array<Type>(std::move(move_)), _maxItems(move_._maxItems) {
             move_._maxItems = 0;
         }
         ~auto_array() {
@@ -1122,7 +1275,7 @@ namespace intercept::types {
         void shrink_to_fit() {
             resize(base::_n);
         }
-        auto_array& operator = (auto_array &&move_) noexcept {
+        auto_array& operator=(auto_array&& move_) noexcept {
             base::_n = move_._n;
             _maxItems = move_._maxItems;
             base::_data = move_._data;
@@ -1132,7 +1285,7 @@ namespace intercept::types {
             return *this;
         }
 
-        auto_array& operator = (const auto_array &copy_) {
+        auto_array& operator=(const auto_array& copy_) {
             if (copy_._n) {
                 insert(base::end(), copy_.begin(), copy_.end());
             }
@@ -1158,9 +1311,9 @@ namespace intercept::types {
                 grow(res_ - _maxItems);
             }
         }
-        template<class... _Valty>
+        template <class... _Valty>
         iterator emplace(iterator where_, _Valty&&... val_) {
-            if (where_ < base::begin() || where_ > base::end()) throw std::runtime_error("Invalid Iterator"); //WTF?!
+            if (where_ < base::begin() || where_ > base::end()) throw std::runtime_error("Invalid Iterator");  //WTF?!
             const size_t insertOffset = where_ - base::begin();
             auto previousEnd = base::_n;
             if (_maxItems < base::_n + 1) {
@@ -1174,7 +1327,7 @@ namespace intercept::types {
 
             return base::begin() + insertOffset;
         }
-        template<class... _Valty>
+        template <class... _Valty>
         iterator emplace_back(_Valty&&... val_) {
             if (_maxItems < base::_n + 1) {
                 grow(1);
@@ -1203,11 +1356,11 @@ namespace intercept::types {
             if (static_cast<int>(index) > base::_n) return;
             auto&& item = (*this)[index];
             item.~Type();
-        #ifdef __GNUC__
+#ifdef __GNUC__
             memmove(&(*this)[index], &(*this)[index + 1], (base::_n - index - 1) * sizeof(Type));
-        #else
+#else
             memmove_s(&(*this)[index], (base::_n - index) * sizeof(Type), &(*this)[index + 1], (base::_n - index - 1) * sizeof(Type));
-        #endif
+#endif
             --base::_n;
         }
 
@@ -1222,11 +1375,11 @@ namespace intercept::types {
                 item.~Type();
             }
             if (last_ != end()) {
-            #ifdef __GNUC__
+#ifdef __GNUC__
                 memmove(&(*this)[firstIndex], &(*this)[lastIndex + 1], (base::_n - lastIndex - 1) * sizeof(Type));
-            #else
+#else
                 memmove_s(&(*this)[firstIndex], (base::_n - firstIndex) * sizeof(Type), &(*this)[lastIndex + 1], (base::_n - lastIndex - 1) * sizeof(Type));
-            #endif
+#endif
             }
             base::_n -= range;
         }
@@ -1239,10 +1392,10 @@ namespace intercept::types {
         }
 
         //This is sooo not threadsafe!
-        template<class _InIt>
+        template <class _InIt>
         iterator insert(iterator _where, _InIt _first, _InIt _last) {
-            if (_first == _last) return _where; //Boogie!
-            if (_where < base::begin() || _where > base::end()) throw std::runtime_error("Invalid Iterator"); //WTF?!
+            if (_first == _last) return _where;                                                                //Boogie!
+            if (_where < base::begin() || _where > base::end()) throw std::runtime_error("Invalid Iterator");  //WTF?!
             const size_t insertOffset = std::distance(base::begin(), _where);
             const size_t previousEnd = static_cast<size_t>(base::_n);
             const size_t oldSize = base::count();
@@ -1285,24 +1438,25 @@ namespace intercept::types {
     template <class Type, class Allocator = rv_allocator<Type>>
     class stack_array : public auto_array<Type, Allocator> {
         using base = auto_array<Type, Allocator>;
+
     public:
         void push(const Type& src) { base::push_back(src); }
-        const Type& top() const { return *(base::end()-1); }
+        const Type& top() const { return *(base::end() - 1); }
         void pop() { base::erase(base::end() - 1); }
     };
-
 
     template <class Type>
     struct find_key_array_traits {
         using key_type = const Type&;
         static bool equals(key_type a_, key_type b_) { return a_ == b_; }
-        static key_type get_key(const Type &a_) { return a_; }
+        static key_type get_key(const Type& a_) { return a_; }
     };
 
-    template<class Type, class Traits = find_key_array_traits<Type>>
+    template <class Type, class Traits = find_key_array_traits<Type>>
     class find_key_array : public auto_array<Type> {
         using base = auto_array<Type>;
         using key_type = typename Traits::key_type;
+
     public:
         void delete_at(uint32_t index_) { base::erase(index_, 1); }
         void delete_at(uint32_t index_, uint32_t count_) { base::erase(index_, count_); }
@@ -1315,8 +1469,9 @@ namespace intercept::types {
 
         void delete_all_by_key(key_type key_) {
             base::erase(std::remove_if(base::begin(), base::end(), [key_](const Type& el) {
-                return Traits::equals(Traits::get_key(el), key_);
-            }), base::end());
+                            return Traits::equals(Traits::get_key(el), key_);
+                        }),
+                        base::end());
         }
 
         std::optional<uint32_t> find(const Type& elem_) const {
@@ -1344,19 +1499,19 @@ namespace intercept::types {
     struct reference_array_find_key_array_traits {
         using key_type = const Type&;
         static bool equals(key_type a_, key_type b_) { return a_ == b_; }
-        static key_type get_key(const Type &a_) { return a_.get(); }
+        static key_type get_key(const Type& a_) { return a_.get(); }
     };
 
     template <class Type>
     class reference_array : public find_key_array<ref<Type>, reference_array_find_key_array_traits<Type>> {
-        using base = find_key_array <ref<Type>, reference_array_find_key_array_traits<Type>>;
+        using base = find_key_array<ref<Type>, reference_array_find_key_array_traits<Type>>;
         using traits = reference_array_find_key_array_traits<Type>;
+
     public:
         using base::delete_at;
 
         bool delete_at(const Type* el_) { return base::delete_by_key(el_); }
         bool delete_at(const ref<Type>& src_) const { return base::delete_by_key(traits::get_key(src_)); }
-
 
         bool find(const Type* el_) { return base::find_by_key(el_); }
         bool find(const ref<Type>& src_) const { return base::find_by_key(traits::get_key(src_)); }

--- a/src/client/headers/shared/containers.hpp
+++ b/src/client/headers/shared/containers.hpp
@@ -832,14 +832,16 @@ namespace intercept::types {
             return _in;
         }
 
-        bool compare_case_sensitive(const char* other_) const {
+        bool compare_case_sensitive(std::string_view other_) const {
+            if (length()  != other_.length()) return false;
             return !std::equal(_ref->cbegin(), _ref->cend(),
-                               compact_array<char>::const_iterator(other_), [](unsigned char l, unsigned char r) { return l == r; });
+                               other_.cbegin(), [](unsigned char l, unsigned char r) { return l == r; });
         }
 
-        bool compare_case_insensitive(const char* other_) const {  //#TODO string_view variant with length checking
+        bool compare_case_insensitive(std::string_view other_) const {
+            if (length() != other_.length()) return false;
             return !std::equal(_ref->cbegin(), _ref->cend(),
-                               compact_array<char>::const_iterator(other_), [](unsigned char l, unsigned char r) { return ::tolower(l) == ::tolower(r); });
+                               other_.cbegin(), [](unsigned char l, unsigned char r) { return ::tolower(l) == ::tolower(r); });
         }
 
         std::string_view substr(size_t offset, size_t length) const {

--- a/src/client/headers/shared/types.hpp
+++ b/src/client/headers/shared/types.hpp
@@ -641,6 +641,30 @@ namespace intercept {
             serialization_return serialize(param_archive& ar) override;
 
             ref<game_data> data;
+
+            //template<class T>
+            //std::enable_if_t<std::is_convertible_v<game_data, T>, ref<T>> get_as() {
+            //    return static_cast<ref<T>>(data);
+            //}
+            //template <class T>
+            //std::enable_if_t<std::is_convertible_v<game_data, T>, const ref<T>> get_as() const {
+            //    return static_cast<const ref<T>>(data);
+            //}
+
+            template <class T>
+            ref<T> get_as() {
+                static_assert(std::is_convertible_v<T, game_data>, "game_value::get_as() can only convert to game_data types");
+                return static_cast<ref<T>>(data);
+            }
+            template <class T>
+            const ref<T> get_as() const {
+                static_assert(std::is_convertible_v<T, game_data>, "game_value::get_as() can only convert to game_data types");
+                return static_cast<const ref<T>>(data);
+            }
+
+
+
+
             [[deprecated]] static void* operator new(std::size_t sz_);  //Should never be used
             static void operator delete(void* ptr_, std::size_t sz_);
 #ifndef __linux__

--- a/src/client/intercept/client/sqf/config.cpp
+++ b/src/client/intercept/client/sqf/config.cpp
@@ -23,14 +23,31 @@ namespace intercept {
             _initialized = move_._initialized;
             return *this;
         }
-        config_entry config_entry::operator>>(sqf_string_const_ref entry_) {
+
+        bool config_entry::operator==(const config_entry& other_) const {
+            if (_initialized != other_._initialized) return false;
+            if (!_initialized) return true;
+            return _config_entry == other_._config_entry;
+        }
+
+        config_entry config_entry::operator>>(sqf_string_const_ref entry_) const {
             if (!_initialized) {
                 _config_entry = host::functions.invoke_raw_nular(__sqf::nular__configfile__ret__config);
                 _initialized = true;
             }
             return config_entry(config(host::functions.invoke_raw_binary(__sqf::binary__configaccessor__config__string__ret__config, _config_entry, entry_)));
         }
-        config_entry::operator config &() {
+
+        config_entry config_entry::operator[](size_t index_) const {
+            return sqf::select(*this, index_);
+        }
+
+        size_t config_entry::count() const {
+            if (!_initialized) return 0;
+            return sqf::count(_config_entry);
+        }
+
+        config_entry::operator config &() const {
             return _config_entry;
         }
 

--- a/src/client/intercept/client/sqf/config.cpp
+++ b/src/client/intercept/client/sqf/config.cpp
@@ -47,6 +47,9 @@ namespace intercept {
             return sqf::count(_config_entry);
         }
 
+        config_entry::iterator config_entry::begin() const { return iterator(*this); }
+        config_entry::iterator config_entry::end() const { return iterator(*this, count() - 1); }
+
         config_entry::operator config &() const {
             return _config_entry;
         }

--- a/src/client/intercept/client/sqf/core.cpp
+++ b/src/client/intercept/client/sqf/core.cpp
@@ -86,8 +86,6 @@ namespace intercept {
             auto gs = allo->gameState;
             if (!_has_fast_call()) return call2(code_, std::move(args_));
 
-            auto missionNamespace = mission_namespace();
- 
             static game_value_static wrapper = sqf::compile("_i135_ar_ call _i135_cc_");
 
             auto data = static_cast<game_data_code*>(wrapper.data.get());

--- a/src/client/intercept/client/sqf/core.cpp
+++ b/src/client/intercept/client/sqf/core.cpp
@@ -81,33 +81,38 @@ namespace intercept {
         }
 
         game_value call(const code &code_, game_value args_) {
-            auto ef = host::functions.get_engine_allocator()->evaluate_func;
-            auto gs = host::functions.get_engine_allocator()->gameState;
-            if (!_has_fast_call()) return call2(code_, args_);
+            auto allo = host::functions.get_engine_allocator();
+            auto ef = allo->evaluate_func;
+            auto gs = allo->gameState;
+            if (!_has_fast_call()) return call2(code_, std::move(args_));
 
             auto missionNamespace = mission_namespace();
  
             static game_value_static wrapper = sqf::compile("_i135_ar_ call _i135_cc_");
 
             auto data = static_cast<game_data_code*>(wrapper.data.get());
-
-            auto ns = missionNamespace.data.get();
+            
+            auto ns = gs->namespaces[3];
             static r_string fname = "interceptCall"sv;
+            static r_string arname = "_i135_ar_"sv;
+            static r_string codename = "_i135_cc_"sv;
 
-            gs->eval->local->variables.insert({"_i135_ar_"sv, args_});
-            gs->eval->local->variables.insert({"_i135_cc_"sv, code_});
+            gs->eval->local->variables.insert({arname, std::move(args_)});
+            gs->eval->local->variables.insert({codename, code_});
 
             auto ret = ef(*data, ns, fname);
             return ret;
         }
 
         game_value call(const code &code_) {
-            auto ef = host::functions.get_engine_allocator()->evaluate_func;
+            auto allo = host::functions.get_engine_allocator();
+            auto ef = allo->evaluate_func;
+            auto gs = allo->gameState;
             if (!ef) return call2(code_);
 
             auto data = static_cast<game_data_code*>(code_.data.get());
 
-            auto ns = mission_namespace().data.get();
+            auto ns = gs->namespaces[3];
             static r_string fname = "interceptCall"sv;
             auto ret = ef(*data, ns, fname);
             return ret;


### PR DESCRIPTION
Ability to construct `ref` from convertible ref's.
Code style cleanup
Added `game_value::get_as`. Can be used to convert game_value to game_data more easily. Like `game_value.get_as<game_data_object>()`
Optimize sqf::call
  Don't reallocate temp variable names everytime.
  Take missionNamespace directly from gameState instead of calling the SQF command.