### PR TITLE
Fix search null char separation

### DIFF
--- a/src/host/extensions/search.cpp
+++ b/src/host/extensions/search.cpp
@@ -47,9 +47,9 @@ namespace intercept::search {
         std::ifstream cmdline("/proc/self/cmdline");
         std::string file_contents;
         std::string line;
-        while (std::getline(cmdline, line)) {
+        while (std::getline(cmdline, line, '\0')) {
             file_contents += line;
-            file_contents.push_back('\n'); //#TODO can linux even have more than one line?
+            file_contents.push_back(' '); //#TODO can linux even have more than one line?
         }
         return file_contents;
     #else

--- a/src/host/extensions/search.cpp
+++ b/src/host/extensions/search.cpp
@@ -49,7 +49,7 @@ namespace intercept::search {
         std::string line;
         while (std::getline(cmdline, line, '\0')) {
             file_contents += line;
-            file_contents.push_back(' '); //#TODO can linux even have more than one line?
+            file_contents.push_back(' ');
         }
         return file_contents;
     #else


### PR DESCRIPTION
@dedmen on Slack:
> https://github.com/intercept/intercept/blob/39549e5ebdb367e79220df7b610fbb9ec1944f84/src/host/extensions/search.cpp#L50
Bug. Seperated by null chars. This outputs a string containing many strings wiht nullchars inbetween. Might not matter if the functions that search the command line use the strings length instead of stopping at first null char. But still bad.
Fix
```
    while (std::getline(cmdline, line, '\0')) {
        file_contents += line;
        file_contents.push_back(' '); //#TODO can linux even have more than one line?
    }
```
> Anyone feel free to PR. I can't right now (edited) 