### PR TITLE
Fix compilation error with VS2019

### DIFF
--- a/src/host/common/dispatch.hpp
+++ b/src/host/common/dispatch.hpp
@@ -13,7 +13,7 @@ using namespace std::literals::chrono_literals;
 namespace intercept {
     class controller_module {
     public:
-        constexpr controller_module() noexcept : _stopped(false) { }
+        controller_module() noexcept : _stopped(false) { }
         ~controller_module() { }
 
         void stop() {


### PR DESCRIPTION
```
src\host\common\dispatch.hpp(16): error C3615: constexpr function 'intercept::controller_module::controller_module' cannot result in a constant expression
src\host\common\dispatch.hpp(16): note: failure was caused by call of undefined function or one not declared 'constexpr'
src\host\common\dispatch.hpp(16): note: see usage of 'std::mutex::mutex'
```