### PR TITLE
Fixed casting const char* to char*

### DIFF
--- a/src/host/extensions/search.cpp
+++ b/src/host/extensions/search.cpp
@@ -228,7 +228,7 @@ typedef struct _OBJECT_TYPE_INFORMATION {
     ULONG NonPagedPoolUsage;
 } OBJECT_TYPE_INFORMATION, *POBJECT_TYPE_INFORMATION;
 
-PVOID GetLibraryProcAddress(PSTR LibraryName, PSTR ProcName) {
+PVOID GetLibraryProcAddress(LPCSTR LibraryName, LPCSTR ProcName) {
     return GetProcAddress(GetModuleHandleA(LibraryName), ProcName);
 }
 


### PR DESCRIPTION
GetLibraryProcAddress is called with const char* arguments, but PSTR is char*, casting const char* to char* won't be allowed anymore in C++20