### PR TITLE
loader: Account for multiple memory regions in maps for linux x64

### DIFF
--- a/src/host/loader/CMakeLists.txt
+++ b/src/host/loader/CMakeLists.txt
@@ -1,3 +1,9 @@
+option(DEBUG_LOADER "DEBUG_LOADER" OFF)
+
+if (DEBUG_LOADER)
+    add_compile_definitions(LOADER_DEBUG=1)
+endif()
+
 file(GLOB_RECURSE INTERCEPT_LOADER_SOURCES *.h *.hpp *.c *.cpp)
 intercept_set_linker_options()
 file(GLOB LOADER_SOURCES *.h *.hpp *.c *.cpp)

--- a/src/host/loader/loader.cpp
+++ b/src/host/loader/loader.cpp
@@ -38,7 +38,7 @@ namespace intercept {
 #if _WIN32 || _WIN64
         explicit MemorySection(const MODULEINFO& modInfo) noexcept :
             start(reinterpret_cast<uintptr_t>(modInfo.lpBaseOfDll)),
-            end(reinterpret_cast<uintptr_t>(modInfo.SizeOfImage) + reinterpret_cast<uintptr_t>(modInfo.lpBaseOfDll)) {}
+            end(static_cast<uintptr_t>(modInfo.SizeOfImage) + reinterpret_cast<uintptr_t>(modInfo.lpBaseOfDll)) {}
 #endif // _WIN32 || _WIN64
         MemorySection(uintptr_t _start, uintptr_t _end) noexcept : start(_start), end(_end) {}
         uintptr_t start;

--- a/src/host/loader/loader.cpp
+++ b/src/host/loader/loader.cpp
@@ -47,7 +47,7 @@ namespace intercept {
             return end - start;
         }
         std::optional<uintptr_t> findInMemory(const char* pattern, size_t patternLength) const {
-            const uintptr_t base = reinterpret_cast<const uintptr_t>(start);
+            const uintptr_t base = start;
             const auto sz = size();
             for (uintptr_t i = 0; i < sz - patternLength; i++) {
                 bool found = true;
@@ -64,7 +64,7 @@ namespace intercept {
             return std::nullopt;
         }
         std::optional<uintptr_t> findInMemoryPattern(const char* pattern, const char* mask, uintptr_t offset = 0) const {
-            const uintptr_t base = reinterpret_cast<const uintptr_t>(start);
+            const uintptr_t base = start;
             const auto sz = size();
             const auto patternLength = strlen(mask);
             for (uintptr_t i = 0; i < sz - patternLength; i++) {
@@ -212,10 +212,6 @@ namespace intercept {
             return true;
         }
         return false;
-    }
-
-    static inline const char* bool_to_str(bool b) {
-        return b ? "true" : "false";
     }
 
     void loader::do_function_walk(uintptr_t state_addr_) {

--- a/src/host/loader/loader.cpp
+++ b/src/host/loader/loader.cpp
@@ -131,7 +131,7 @@ namespace intercept {
                 #endif
 
                 // Add section to array
-                sections.push_back(MemorySection(reinterpret_cast<uintptr_t>(startParsed), reinterpret_cast<uintptr_t>(endParsed)));
+                sections.push_back(MemorySection(static_cast<uintptr_t>(startParsed), static_cast<uintptr_t>(endParsed)));
             }
         }
 #endif // defined(__linux__)


### PR DESCRIPTION
This change is required to support the new compiler that began being
used with the 2.08 v18+ versions of the performance branch on linux x64