### PR TITLE
Added support for hashmap type

### DIFF
--- a/src/client/headers/client/sqf/common_helpers.hpp
+++ b/src/client/headers/client/sqf/common_helpers.hpp
@@ -1,4 +1,4 @@
-﻿/*!
+/*!
 @file
 @author Verox (verox.averre@gmail.com)
 @author Nou (korewananda@gmail.com)
@@ -70,6 +70,10 @@ namespace intercept {
                 if (input_.size() == 0) return {};
                 auto& arr = input_.to_array();
                 return std::vector<T>(arr.begin(), arr.end());
+            }
+
+            inline rv_hashmap __convert_to_hashmap(const game_value& input_) {
+                return std::move(input_.get_as<game_data_hashmap>()->data);
             }
 
 

--- a/src/client/headers/client/sqf/core.hpp
+++ b/src/client/headers/client/sqf/core.hpp
@@ -354,6 +354,8 @@ namespace intercept {
         bool is_steam_overlay_enabled();
         bool is_saving();
 
+        rv_hashmap get_video_options();
+
         void set_ti_parameter(sqf_string_const_ref param_, float value_);
     }  // namespace sqf
 }  // namespace intercept

--- a/src/client/headers/client/sqf/core.hpp
+++ b/src/client/headers/client/sqf/core.hpp
@@ -355,7 +355,7 @@ namespace intercept {
         bool is_saving();
 
         rv_hashmap get_video_options();
-
+        rv_hashmap get_ti_parameters();
         void set_ti_parameter(sqf_string_const_ref param_, float value_);
     }  // namespace sqf
 }  // namespace intercept

--- a/src/client/headers/client/sqf/inventory.hpp
+++ b/src/client/headers/client/sqf/inventory.hpp
@@ -638,6 +638,9 @@ namespace intercept {
         void remove_all_binocular_items(const object &unit_);
         void remove_all_secondary_weapon_items(const object &unit_);
         sqf_return_string_list backpacks(const object &unit_);
+
+        rv_hashmap unique_unit_items(const object &unit_);
+        rv_hashmap unique_unit_items_filtered(const object &unit_, int weapons_items_ = 2, int uniform_items_ = 2, int vest_items = 2, int backpack_items_ = 2, int assigned_items_ = 2);
         
     }  // namespace sqf
 }  // namespace intercept

--- a/src/client/headers/shared/client_types.hpp
+++ b/src/client/headers/shared/client_types.hpp
@@ -490,13 +490,9 @@ namespace intercept {
             obj_type_temporary = 4,
             obj_type_vehicle = 8,
             obj_type_temp_veh = 16,
-            obj_type_land_decal = 32,
-            obj_type_all = 63,
-            obj_type_all_inc_null = -1
+            obj_type_land_decal = 32
         };
-#ifdef DEFINE_ENUM_FLAG_OPERATORS
-        DEFINE_ENUM_FLAG_OPERATORS(object_types)
-#endif
+
         enum class object_simulation_kind {
             Statics = 0,
             Slow = 0,

--- a/src/client/headers/shared/client_types.hpp
+++ b/src/client/headers/shared/client_types.hpp
@@ -523,7 +523,7 @@ namespace std {
     
 #define DEFINE_HASH_FUNCTION_FOR_CLASS(type) template <> struct hash<intercept::types::type> { \
         size_t operator()(const intercept::types::type& x) const { \
-            return x.hash(); \
+            return x.get_hash(); \
         } \
     }; 
 

--- a/src/client/headers/shared/client_types.hpp
+++ b/src/client/headers/shared/client_types.hpp
@@ -490,9 +490,13 @@ namespace intercept {
             obj_type_temporary = 4,
             obj_type_vehicle = 8,
             obj_type_temp_veh = 16,
-            obj_type_land_decal = 32
+            obj_type_land_decal = 32,
+            obj_type_all = 63,
+            obj_type_all_inc_null = -1
         };
-
+#ifdef DEFINE_ENUM_FLAG_OPERATORS
+        DEFINE_ENUM_FLAG_OPERATORS(object_types)
+#endif
         enum class object_simulation_kind {
             Statics = 0,
             Slow = 0,

--- a/src/client/headers/shared/containers.hpp
+++ b/src/client/headers/shared/containers.hpp
@@ -1654,6 +1654,7 @@ namespace intercept::types {
         return hashValue;
     }
 
+
     struct map_string_to_class_trait {
         /*
         static unsigned int hash_key(const char* key) noexcept {
@@ -1663,6 +1664,7 @@ namespace intercept::types {
             return strcmp(k1, k2) == 0;
         }
         */
+
         static unsigned int hash_key(std::string_view key) noexcept {
             return rv_map_hash_string_case_sensitive(key);
         }
@@ -1801,7 +1803,8 @@ namespace intercept::types {
             }
         }
 
-        const Type& get(std::string_view key_) const {
+        template <class T>
+        const Type& get(T&& key_) const {
             if (!_table || !_count) return _null_entry;
             const int hashed_key = hash_key(key_);
             for (size_t i = 0; i < _table[hashed_key].count(); i++) {
@@ -1812,19 +1815,22 @@ namespace intercept::types {
             return _null_entry;
         }
 
-        Container* get_table_for_key(std::string_view key_) {
+        template <class T>
+        Container* get_table_for_key(T&& key_) {
             if (!_table || !_count) return nullptr;
             const int hashed_key = hash_key(key_);
             return &_table[hashed_key];
         }
 
-        const Container* get_table_for_key(std::string_view key_) const {
+        template <class T>
+        const Container* get_table_for_key(T&& key_) const {
             if (!_table || !_count) return nullptr;
             const int hashed_key = hash_key(key_);
             return &_table[hashed_key];
         }
 
-        Type& get(std::string_view key_) {
+        template <class T>
+        Type& get(T&& key_) {
             if (!_table || !_count) return _null_entry;
             const int hashed_key = hash_key(key_);
             for (size_t i = 0; i < _table[hashed_key].count(); i++) {
@@ -1837,7 +1843,8 @@ namespace intercept::types {
 
         static bool is_null(const Type& value_) { return &value_ == &_null_entry; }
 
-        bool has_key(std::string_view key_) const {
+        template <class T>
+        bool has_key(T&& key_) const {
             return !is_null(get(key_));
         }
 
@@ -1910,7 +1917,8 @@ namespace intercept::types {
             return x;
         }
 
-        bool remove(std::string_view key) {
+        template <class T>
+        bool remove(T&& key) {
             if (_count <= 0) return false;
 
             int hashedKey = hash_key(key);
@@ -1926,12 +1934,14 @@ namespace intercept::types {
         }
 
         //Is empty?
-        bool empty() {
+        bool empty() const {
             return (!_table || !_count);
         }
 
     protected:
-        int hash_key(std::string_view key_) const {
+
+        template <class T>
+        int hash_key(T&& key_) const {
             return Traits::hash_key(key_) % _tableCount;
         }
     };

--- a/src/client/headers/shared/containers.hpp
+++ b/src/client/headers/shared/containers.hpp
@@ -1710,7 +1710,6 @@ namespace intercept::types {
         int _tableCount{0};
         int _count{0};
         static Type _null_entry;
-
     public:
         class iterator {
             size_t _table;
@@ -1961,11 +1960,15 @@ namespace intercept::types {
             return (!_table || !_count);
         }
 
-        void reserve(int newTable) {
-            if (newTable <= _tableCount)
-                return;
-
-            rebuild(newTable);
+        void reserve(int newCount_) {
+            int newTableCount_ = newCount_ / 16; 
+            if (newTableCount_ > _tableCount) {
+                rebuild(newTableCount_);
+            }
+            for (auto i = 0; i < _tableCount; ++i) {
+                auto& container = _table[i];
+                container.reserve(16);
+            }
         }
 
         void clear(bool reclaim_memory_ = false) {

--- a/src/client/headers/shared/containers.hpp
+++ b/src/client/headers/shared/containers.hpp
@@ -1998,56 +1998,57 @@ namespace intercept::types {
 
     template <class Type, class Container, class Traits>
     class internal_hashmap : public map_string_to_class<Type, Container, Traits> {
+        using base = map_string_to_class<Type, Container, Traits>;
     public:
         typename Type::value_type& operator[](typename Type::key_type key_) {
-            auto& temp = this->get(key_);
-            if (this->is_null(temp)) {
-                return this->insert(Type(key_, Type::value_type())).value;
+            auto& temp = base::get(key_);
+            if (base::is_null(temp)) {
+                return base::insert(Type(key_, Type::value_type())).value;
             }
             return temp.value;
         }
         const typename Type::value_type& operator[](typename Type::key_type key_) const {
-            return this->at(key_);
+            return base::at(key_);
         }
         typename Type::value_type& at(typename Type::key_type key_) {
-            auto& temp = this->get(key_);
-            if (this->is_null(temp)) {
+            auto& temp = base::get(key_);
+            if (base::is_null(temp)) {
                 throw std::out_of_range("Invalid key");
             }
             return temp.value;
         }
         const typename Type::value_type& at(typename Type::key_type key_) const {
-            auto& temp = this->get(key_);
-            if (this->is_null(temp)) {
+            auto& temp = base::get(key_);
+            if (base::is_null(temp)) {
                 throw std::out_of_range("Invalid key");
             }
             return temp.value;
         }
 
-        template<class...Args>
-        Type& emplace(Args&&...args_) {
-            return this->insert(Type(std::forward<Args>(args_)...));
+        template <class... Args>
+        Type& emplace(Args&&... args_) {
+            return base::insert(Type(std::forward<Args>(args_)...));
         }
 
         Type* find(typename Type::key_type key_) {
-            auto& temp = this->get(key_);
-            if (this->is_null(temp))
+            auto& temp = base::get(key_);
+            if (base::is_null(temp))
                 return nullptr;
             return &temp;
         }
         const Type* find(typename Type::key_type key_) const {
-            auto& temp = this->get(key_);
-            if (this->is_null(temp))
+            auto& temp = base::get(key_);
+            if (base::is_null(temp))
                 return nullptr;
             return &temp;
         }
 
         bool contains(typename Type::key_type key_) const {
-            return this->has_key(key_);
+            return base::has_key(key_);
         }
 
         ~internal_hashmap() {
-            this->clear(true);
+            base::clear(true);
         }
     };
 

--- a/src/client/headers/shared/containers.hpp
+++ b/src/client/headers/shared/containers.hpp
@@ -1991,7 +1991,7 @@ namespace intercept::types {
         }
 
         template<class...Args>
-        typename Type& emplace(Args&&...args_) {
+        Type& emplace(Args&&...args_) {
             return this->insert(Type(std::forward<Args>(args_)...));
         }
 

--- a/src/client/headers/shared/types.hpp
+++ b/src/client/headers/shared/types.hpp
@@ -503,8 +503,6 @@ namespace intercept {
             virtual void placeholder() const {}
             virtual bool can_serialize() { return false; }
 
-        public:
-
         private:
             int IaddRef() override { return add_ref(); }
             int Irelease() override { return release(); }

--- a/src/client/headers/shared/types.hpp
+++ b/src/client/headers/shared/types.hpp
@@ -42,7 +42,7 @@ namespace intercept {
         class game_data_hashmap;
         struct game_data_hashmap_pair;
         struct game_data_hashmap_traits;
-        using game_hashmap_type = rv_hashmap<game_data_hashmap_pair, auto_array<game_data_hashmap_pair>, game_data_hashmap_traits>;
+        using rv_hashmap = internal_hashmap<game_data_hashmap_pair, auto_array<game_data_hashmap_pair>, game_data_hashmap_traits>;
         class internal_object;
         class game_data;
         class game_state;
@@ -628,7 +628,7 @@ namespace intercept {
             * @throws game_value_conversion_error {if game_value is not an array}
             */
             auto_array<game_value>& to_array() const;
-            game_hashmap_type& to_hashmap() const;
+            rv_hashmap& to_hashmap() const;
 
             /**
             * @brief tries to convert the game_value to an array if possible and return the element at given index.
@@ -659,7 +659,7 @@ namespace intercept {
             bool is_equalto_with_nil(const game_value& other) const;
 
             uint64_t get_hash() const;
-            size_t hash() const;
+            [[deprecated]] size_t hash() const;
             //set's this game_value to null
             void clear() { data = nullptr; }
 
@@ -891,7 +891,7 @@ namespace intercept {
             static void operator delete(void* ptr_, std::size_t sz_);
             float number;
             size_t hash() const {
-                return __internal::pairhash(type_def, number);
+                return this->get_hash();
             }
             //protected:
             //    static thread_local game_data_pool<game_data_number> _data_pool;
@@ -911,7 +911,7 @@ namespace intercept {
             static void* operator new(std::size_t sz_);
             static void operator delete(void* ptr_, std::size_t sz_);
             bool val;
-            size_t hash() const { return __internal::pairhash(type_def, val); }
+            size_t hash() const { return this->get_hash(); }
             //protected:
             //    static thread_local game_data_pool<game_data_bool> _data_pool;
         };
@@ -952,7 +952,7 @@ namespace intercept {
             static void* operator new(std::size_t sz_);
             static void operator delete(void* ptr_, std::size_t sz_);
         
-            game_hashmap_type data;
+            rv_hashmap data;
             bool _readOnly = false;
         };
 
@@ -973,7 +973,7 @@ namespace intercept {
             ~game_data_array();
             auto_array<game_value> data;
             auto length() const { return data.count(); }
-            size_t hash() const { return __internal::pairhash(type_def, data.hash()); }
+            size_t hash() const { return this->get_hash(); }
             static void* operator new(std::size_t sz_);
             static void operator delete(void* ptr_, std::size_t sz_);
         };
@@ -992,7 +992,7 @@ namespace intercept {
             game_data_string& operator=(game_data_string&& move_) noexcept;
             ~game_data_string();
             r_string raw_string;
-            size_t hash() const { return __internal::pairhash(type_def, raw_string); }
+            size_t hash() const { return this->get_hash(); }
             static void* operator new(std::size_t sz_);
             static void operator delete(void* ptr_, std::size_t sz_);
             //protected:
@@ -1007,7 +1007,7 @@ namespace intercept {
                 *reinterpret_cast<uintptr_t*>(this) = type_def;
                 *reinterpret_cast<uintptr_t*>(static_cast<I_debug_value*>(this)) = data_type_def;
             }
-            size_t hash() const { return __internal::pairhash(type_def, group); }
+            size_t hash() const { return this->get_hash(); }
             void* group{};
         };
 
@@ -1019,7 +1019,7 @@ namespace intercept {
                 *reinterpret_cast<uintptr_t*>(this) = type_def;
                 *reinterpret_cast<uintptr_t*>(static_cast<I_debug_value*>(this)) = data_type_def;
             }
-            size_t hash() const { return __internal::pairhash(type_def, config); }
+            size_t hash() const { return this->get_hash(); }
             void* config{};
             auto_array<r_string> path;
         };
@@ -1032,7 +1032,7 @@ namespace intercept {
                 *reinterpret_cast<uintptr_t*>(this) = type_def;
                 *reinterpret_cast<uintptr_t*>(static_cast<I_debug_value*>(this)) = data_type_def;
             }
-            size_t hash() const { return __internal::pairhash(type_def, control); }
+            size_t hash() const { return this->get_hash(); }
             void* control{};
         };
 
@@ -1044,7 +1044,7 @@ namespace intercept {
                 *reinterpret_cast<uintptr_t*>(this) = type_def;
                 *reinterpret_cast<uintptr_t*>(static_cast<I_debug_value*>(this)) = data_type_def;
             }
-            size_t hash() const { return __internal::pairhash(type_def, display); }
+            size_t hash() const { return this->get_hash(); }
             void* display{};
         };
 
@@ -1056,7 +1056,7 @@ namespace intercept {
                 *reinterpret_cast<uintptr_t*>(this) = type_def;
                 *reinterpret_cast<uintptr_t*>(static_cast<I_debug_value*>(this)) = data_type_def;
             }
-            size_t hash() const { return __internal::pairhash(type_def, location); }
+            size_t hash() const { return this->get_hash(); }
             void* location{};
         };
 
@@ -1068,7 +1068,7 @@ namespace intercept {
                 *reinterpret_cast<uintptr_t*>(this) = type_def;
                 *reinterpret_cast<uintptr_t*>(static_cast<I_debug_value*>(this)) = data_type_def;
             }
-            size_t hash() const { return __internal::pairhash(type_def, script); }
+            size_t hash() const { return this->get_hash(); }
             void* script{};
         };
 
@@ -1080,7 +1080,7 @@ namespace intercept {
                 *reinterpret_cast<uintptr_t*>(this) = type_def;
                 *reinterpret_cast<uintptr_t*>(static_cast<I_debug_value*>(this)) = data_type_def;
             }
-            size_t hash() const { return __internal::pairhash(type_def, side); }
+            size_t hash() const { return this->get_hash(); }
             void* side{};
         };
 
@@ -1092,7 +1092,7 @@ namespace intercept {
                 *reinterpret_cast<uintptr_t*>(this) = type_def;
                 *reinterpret_cast<uintptr_t*>(static_cast<I_debug_value*>(this)) = data_type_def;
             }
-            size_t hash() const { return __internal::pairhash(type_def, rv_text); }
+            size_t hash() const { return this->get_hash(); }
             void* rv_text{};
         };
 
@@ -1104,7 +1104,7 @@ namespace intercept {
                 *reinterpret_cast<uintptr_t*>(this) = type_def;
                 *reinterpret_cast<uintptr_t*>(static_cast<I_debug_value*>(this)) = data_type_def;
             }
-            size_t hash() const { return __internal::pairhash(type_def, team); }
+            size_t hash() const { return this->get_hash(); }
             void* team{};
         };
 
@@ -1116,7 +1116,7 @@ namespace intercept {
                 *reinterpret_cast<uintptr_t*>(this) = type_def;
                 *reinterpret_cast<uintptr_t*>(static_cast<I_debug_value*>(this)) = data_type_def;
             }
-            size_t hash() const { return __internal::pairhash(type_def, 0); }  //#TODO proper hashing
+            size_t hash() const { return this->get_hash(); }  //#TODO proper hashing
 
             map_string_to_class<game_variable, auto_array<game_variable>> _variables;
             r_string _name;
@@ -1161,7 +1161,7 @@ namespace intercept {
                 *reinterpret_cast<uintptr_t*>(this) = type_def;
                 *reinterpret_cast<uintptr_t*>(static_cast<I_debug_value*>(this)) = data_type_def;
             }
-            size_t hash() const { return __internal::pairhash(type_def, code_string); }
+            size_t hash() const { return this->get_hash(); }
             static void* operator new(std::size_t sz_);
             static void operator delete(void* ptr_, std::size_t sz_);
             r_string code_string;
@@ -1177,7 +1177,7 @@ namespace intercept {
                 *reinterpret_cast<uintptr_t*>(this) = type_def;
                 *reinterpret_cast<uintptr_t*>(static_cast<I_debug_value*>(this)) = data_type_def;
             }
-            size_t hash() const { return __internal::pairhash(type_def, reinterpret_cast<uintptr_t>(object ? object->object : object)); }
+            size_t hash() const { return this->get_hash(); }
             struct visualState {
                 //will be false if you called stuff on nullObj
                 bool valid{false};

--- a/src/client/headers/shared/types.hpp
+++ b/src/client/headers/shared/types.hpp
@@ -39,6 +39,7 @@ namespace intercept {
         class game_value;
         using game_value_parameter = const game_value&;
         class game_data_array;
+        class game_data_hashmap;
         class internal_object;
         class game_data;
         class game_state;
@@ -69,6 +70,7 @@ namespace intercept {
             NetObject,
             SUBGROUP,
             TEAM_MEMBER,
+            HASHMAP,
             TASK,
             DIARY_RECORD,
             LOCATION,
@@ -498,6 +500,9 @@ namespace intercept {
             virtual void placeholder() const {}
             virtual bool can_serialize() { return false; }
 
+        public:
+
+        private:
             int IaddRef() override { return add_ref(); }
             int Irelease() override { return release(); }
 
@@ -510,6 +515,8 @@ namespace intercept {
 
                 return serialization_return::no_error;
             }
+            virtual uint64_t get_hash() const { return 0; }
+
             static game_data* createFromSerialized(param_archive& ar);
 
         protected:
@@ -554,13 +561,13 @@ namespace intercept {
                 copy(copy_);
             }
 
-#pragma optimize("ts", on)
+//#pragma optimize("ts", on)
             game_value(game_value&& move_) noexcept {
                 set_vtable(__vptr_def);  //Whatever vtable move_ has.. if it's different then it's wrong
                 data = nullptr;
                 data.swap(move_.data);
             }
-#pragma optimize("", on)
+//#pragma optimize("", on)
 
             //Conversions
             game_value(game_data* val_) noexcept {
@@ -618,6 +625,7 @@ namespace intercept {
             * @throws game_value_conversion_error {if game_value is not an array}
             */
             auto_array<game_value>& to_array() const;
+            game_data_hashmap& to_hashmap() const;
 
             /**
             * @brief tries to convert the game_value to an array if possible and return the element at given index.
@@ -645,6 +653,7 @@ namespace intercept {
 
             bool operator==(const game_value& other) const;
             bool operator!=(const game_value& other) const;
+            bool is_equalto_with_nil(const game_value& other) const;
 
             size_t hash() const;
             //set's this game_value to null
@@ -685,11 +694,11 @@ namespace intercept {
             uintptr_t get_vtable() const noexcept {
                 return *reinterpret_cast<const uintptr_t*>(this);
             }
-#pragma optimize("ts", on)
+//#pragma optimize("ts", on)
             void set_vtable(uintptr_t vt) noexcept {
                 *reinterpret_cast<uintptr_t*>(this) = vt;
             }
-#pragma optimize("", on)
+//#pragma optimize("", on)
         };
 
         class game_value_static : public game_value {
@@ -901,6 +910,73 @@ namespace intercept {
             size_t hash() const { return __internal::pairhash(type_def, val); }
             //protected:
             //    static thread_local game_data_pool<game_data_bool> _data_pool;
+        };
+
+        class game_data_hashmap : public game_data {
+        public:
+            struct pair {
+                game_value key;
+                game_value value;
+                const game_value& get_map_key() const { return key; }
+                game_value& get_map_key() { return key; }
+            };
+            static uintptr_t type_def;
+            static uintptr_t data_type_def;
+            static rv_pool_allocator* pool_alloc_base;
+
+            struct traits {
+                static uint64_t hash_key(const game_value& key) noexcept {
+                    return key.data->get_hash();
+                }
+                static bool compare_keys(const game_value& k1, const game_value& k2) noexcept {
+                    return k1.is_equalto_with_nil(k2);
+                }
+            };
+
+            using game_hashmap_type = map_string_to_class<game_data_hashmap::pair, auto_array<game_data_hashmap::pair>, game_data_hashmap::traits>;
+
+            game_data_hashmap();
+            game_data_hashmap(const game_data_hashmap& copy_);
+            game_data_hashmap(game_data_hashmap&& move_) noexcept;
+            game_data_hashmap& operator=(const game_data_hashmap& copy_);
+            game_data_hashmap& operator=(game_data_hashmap&& move_) noexcept;
+            ~game_data_hashmap();
+
+            game_value& operator[](const game_value& v);
+            game_value& at(const game_value& v);
+            const game_value& operator[](const game_value& v) const;
+            const game_value& at(const game_value& v) const;
+            template<class T>
+            T get(const game_value& v) const {
+                return T{this->at(v)};
+            }
+            template<class T1, class T2>
+            pair& emplace(T1&& key, T2&& value) {
+                return data.insert(pair(std::forward<T1>(key), std::forward<T2>(value)));
+            }
+            void insert(const pair& pair);
+            void insert(const game_value& key, const game_value& value);
+            void insert(const game_data_hashmap& other);
+
+            void resize(int size);
+            void clear();
+            bool remove(const game_value& key);
+
+            inline game_hashmap_type::iterator begin() { return data.begin(); }
+            inline game_hashmap_type::iterator end() { return data.end(); }
+
+            pair* find(const game_value& key);
+            const pair* find(const game_value& key) const;
+            bool contains(const game_value& key) const;
+
+            inline int size() const { return data.count(); }
+            inline bool empty() const { return data.empty(); }
+
+            static void* operator new(std::size_t sz_);
+            static void operator delete(void* ptr_, std::size_t sz_);
+        private:
+            game_hashmap_type data;
+            bool _readOnly = false;
         };
 
         class game_data_array : public game_data {
@@ -1589,7 +1665,7 @@ namespace std {
     template <>
     struct hash<intercept::types::game_value> {
         size_t operator()(const intercept::types::game_value& x) const {
-            return x.hash();
+            return x.data->get_hash();
         }
     };
 }  // namespace std

--- a/src/client/headers/shared/types.hpp
+++ b/src/client/headers/shared/types.hpp
@@ -657,7 +657,8 @@ namespace intercept {
             bool is_equalto_with_nil(const game_value& other) const;
 
             uint64_t get_hash() const;
-            [[deprecated]] size_t hash() const;
+            [[deprecated("Use get_hash instead")]] uint64_t hash() const { return this->get_hash(); }
+
             //set's this game_value to null
             void clear() { data = nullptr; }
 
@@ -888,9 +889,6 @@ namespace intercept {
             static void* operator new(std::size_t sz_);
             static void operator delete(void* ptr_, std::size_t sz_);
             float number;
-            size_t hash() const {
-                return this->get_hash();
-            }
             //protected:
             //    static thread_local game_data_pool<game_data_number> _data_pool;
         };
@@ -909,7 +907,6 @@ namespace intercept {
             static void* operator new(std::size_t sz_);
             static void operator delete(void* ptr_, std::size_t sz_);
             bool val;
-            size_t hash() const { return this->get_hash(); }
             //protected:
             //    static thread_local game_data_pool<game_data_bool> _data_pool;
         };
@@ -971,7 +968,6 @@ namespace intercept {
             ~game_data_array();
             auto_array<game_value> data;
             auto length() const { return data.count(); }
-            size_t hash() const { return this->get_hash(); }
             static void* operator new(std::size_t sz_);
             static void operator delete(void* ptr_, std::size_t sz_);
         };
@@ -990,7 +986,6 @@ namespace intercept {
             game_data_string& operator=(game_data_string&& move_) noexcept;
             ~game_data_string();
             r_string raw_string;
-            size_t hash() const { return this->get_hash(); }
             static void* operator new(std::size_t sz_);
             static void operator delete(void* ptr_, std::size_t sz_);
             //protected:
@@ -1005,7 +1000,6 @@ namespace intercept {
                 *reinterpret_cast<uintptr_t*>(this) = type_def;
                 *reinterpret_cast<uintptr_t*>(static_cast<I_debug_value*>(this)) = data_type_def;
             }
-            size_t hash() const { return this->get_hash(); }
             void* group{};
         };
 
@@ -1017,7 +1011,6 @@ namespace intercept {
                 *reinterpret_cast<uintptr_t*>(this) = type_def;
                 *reinterpret_cast<uintptr_t*>(static_cast<I_debug_value*>(this)) = data_type_def;
             }
-            size_t hash() const { return this->get_hash(); }
             void* config{};
             auto_array<r_string> path;
         };
@@ -1030,7 +1023,6 @@ namespace intercept {
                 *reinterpret_cast<uintptr_t*>(this) = type_def;
                 *reinterpret_cast<uintptr_t*>(static_cast<I_debug_value*>(this)) = data_type_def;
             }
-            size_t hash() const { return this->get_hash(); }
             void* control{};
         };
 
@@ -1042,7 +1034,6 @@ namespace intercept {
                 *reinterpret_cast<uintptr_t*>(this) = type_def;
                 *reinterpret_cast<uintptr_t*>(static_cast<I_debug_value*>(this)) = data_type_def;
             }
-            size_t hash() const { return this->get_hash(); }
             void* display{};
         };
 
@@ -1054,7 +1045,6 @@ namespace intercept {
                 *reinterpret_cast<uintptr_t*>(this) = type_def;
                 *reinterpret_cast<uintptr_t*>(static_cast<I_debug_value*>(this)) = data_type_def;
             }
-            size_t hash() const { return this->get_hash(); }
             void* location{};
         };
 
@@ -1066,7 +1056,6 @@ namespace intercept {
                 *reinterpret_cast<uintptr_t*>(this) = type_def;
                 *reinterpret_cast<uintptr_t*>(static_cast<I_debug_value*>(this)) = data_type_def;
             }
-            size_t hash() const { return this->get_hash(); }
             void* script{};
         };
 
@@ -1078,7 +1067,6 @@ namespace intercept {
                 *reinterpret_cast<uintptr_t*>(this) = type_def;
                 *reinterpret_cast<uintptr_t*>(static_cast<I_debug_value*>(this)) = data_type_def;
             }
-            size_t hash() const { return this->get_hash(); }
             void* side{};
         };
 
@@ -1090,7 +1078,6 @@ namespace intercept {
                 *reinterpret_cast<uintptr_t*>(this) = type_def;
                 *reinterpret_cast<uintptr_t*>(static_cast<I_debug_value*>(this)) = data_type_def;
             }
-            size_t hash() const { return this->get_hash(); }
             void* rv_text{};
         };
 
@@ -1102,7 +1089,6 @@ namespace intercept {
                 *reinterpret_cast<uintptr_t*>(this) = type_def;
                 *reinterpret_cast<uintptr_t*>(static_cast<I_debug_value*>(this)) = data_type_def;
             }
-            size_t hash() const { return this->get_hash(); }
             void* team{};
         };
 
@@ -1114,7 +1100,6 @@ namespace intercept {
                 *reinterpret_cast<uintptr_t*>(this) = type_def;
                 *reinterpret_cast<uintptr_t*>(static_cast<I_debug_value*>(this)) = data_type_def;
             }
-            size_t hash() const { return this->get_hash(); }  //#TODO proper hashing
 
             map_string_to_class<game_variable, auto_array<game_variable>> _variables;
             r_string _name;
@@ -1129,7 +1114,7 @@ namespace intercept {
                 *reinterpret_cast<uintptr_t*>(this) = type_def;
                 *reinterpret_cast<uintptr_t*>(static_cast<I_debug_value*>(this)) = data_type_def;
             }
-            static size_t hash() { return 0x1337; }
+            static uint64_t hash() { return 0XCBF29CE484222325; } //64bit FNV-1 offset basis
         };
 
         class game_instruction : public refcount {
@@ -1159,7 +1144,6 @@ namespace intercept {
                 *reinterpret_cast<uintptr_t*>(this) = type_def;
                 *reinterpret_cast<uintptr_t*>(static_cast<I_debug_value*>(this)) = data_type_def;
             }
-            size_t hash() const { return this->get_hash(); }
             static void* operator new(std::size_t sz_);
             static void operator delete(void* ptr_, std::size_t sz_);
             r_string code_string;
@@ -1175,7 +1159,6 @@ namespace intercept {
                 *reinterpret_cast<uintptr_t*>(this) = type_def;
                 *reinterpret_cast<uintptr_t*>(static_cast<I_debug_value*>(this)) = data_type_def;
             }
-            size_t hash() const { return this->get_hash(); }
             struct visualState {
                 //will be false if you called stuff on nullObj
                 bool valid{false};

--- a/src/client/headers/shared/types.hpp
+++ b/src/client/headers/shared/types.hpp
@@ -1114,7 +1114,7 @@ namespace intercept {
                 *reinterpret_cast<uintptr_t*>(this) = type_def;
                 *reinterpret_cast<uintptr_t*>(static_cast<I_debug_value*>(this)) = data_type_def;
             }
-            static uint64_t hash() { return 0XCBF29CE484222325; } //64bit FNV-1 offset basis
+            static uint64_t hash() { return 0xCBF29CE484222325; } //64bit FNV-1 offset basis
         };
 
         class game_instruction : public refcount {

--- a/src/client/headers/shared/types.hpp
+++ b/src/client/headers/shared/types.hpp
@@ -926,6 +926,8 @@ namespace intercept {
             game_data_hashmap_pair(const game_value& k_, const game_value& v_) : key(k_), value(v_) {}
         };
         struct game_data_hashmap_traits {
+            using key_type = const game_value&;
+
             static uint64_t hash_key(const game_value& key) noexcept {
                 return key.data->get_hash();
             }

--- a/src/client/intercept/client/client.cpp
+++ b/src/client/intercept/client/client.cpp
@@ -71,6 +71,11 @@ namespace intercept {
             game_data_array::data_type_def = data_type_def;
             game_data_array::pool_alloc_base = allocator_info->_poolAllocs[static_cast<size_t>(game_data_type::ARRAY)];
 
+            host::functions.get_type_structure("HASHMAP"sv, type_def, data_type_def);
+            game_data_hashmap::type_def = type_def;
+            game_data_hashmap::data_type_def = data_type_def;
+            game_data_hashmap::pool_alloc_base = allocator_info->_poolAllocs[static_cast<size_t>(game_data_type::HASHMAP)];
+
 
             host::functions.get_type_structure("SCALAR"sv, type_def, data_type_def);
             game_data_number::type_def = type_def;

--- a/src/client/intercept/client/sqf/core.cpp
+++ b/src/client/intercept/client/sqf/core.cpp
@@ -1109,6 +1109,10 @@ namespace intercept {
             return __helpers::__convert_to_hashmap(host::functions.invoke_raw_nular(__sqf::nular__getvideooptions__ret__hashmap));
         }
 
+        rv_hashmap get_ti_parameters() {
+            return __helpers::__convert_to_hashmap(host::functions.invoke_raw_nular(__sqf::nular__gettiparameters__ret__hashmap));
+        }
+
         void set_ti_parameter(sqf_string_const_ref param_, float value_) {
             host::functions.invoke_raw_unary(__sqf::unary__settiparameter__array__ret__nothing, {param_, value_});
         }

--- a/src/client/intercept/client/sqf/core.cpp
+++ b/src/client/intercept/client/sqf/core.cpp
@@ -1105,6 +1105,10 @@ namespace intercept {
             return host::functions.invoke_raw_nular(__sqf::nular__issaving__ret__bool);
         }
 
+        rv_hashmap get_video_options() {
+            return __helpers::__convert_to_hashmap(host::functions.invoke_raw_nular(__sqf::nular__getvideooptions__ret__hashmap));
+        }
+
         void set_ti_parameter(sqf_string_const_ref param_, float value_) {
             host::functions.invoke_raw_unary(__sqf::unary__settiparameter__array__ret__nothing, {param_, value_});
         }

--- a/src/client/intercept/client/sqf/inventory.cpp
+++ b/src/client/intercept/client/sqf/inventory.cpp
@@ -934,5 +934,14 @@ namespace intercept {
         sqf_return_string_list backpacks(const object &unit_) {
             return __helpers::__convert_to_vector<sqf_return_string>(host::functions.invoke_raw_unary(__sqf::unary__backpacks__object__ret__array, unit_));
         }
+
+        rv_hashmap unique_unit_items(const object& unit_) {
+            return __helpers::__convert_to_hashmap(host::functions.invoke_raw_unary(__sqf::unary__uniqueunititems__object_array__ret__hashmap, unit_));
+        }
+
+        rv_hashmap unique_unit_items_filtered(const object& unit_, int weapons_items_, int uniform_items_, int vest_items, int backpack_items_, int assigned_items_) {
+            return __helpers::__convert_to_hashmap(host::functions.invoke_raw_unary(__sqf::unary__uniqueunititems__object_array__ret__hashmap, {unit_, weapons_items_, uniform_items_, vest_items, backpack_items_, assigned_items_}));
+        }
+        
     }  // namespace sqf
 }  // namespace intercept

--- a/src/client/intercept/shared/types.cpp
+++ b/src/client/intercept/shared/types.cpp
@@ -733,12 +733,12 @@ namespace intercept {
             return dummy;
         }
 
-        game_hashmap_type &game_value::to_hashmap() const {
+        rv_hashmap &game_value::to_hashmap() const {
             if (data) {
                 if (data->get_vtable() != game_data_hashmap::type_def) throw game_value_conversion_error("Invalid conversion to hashmap");
                 return static_cast<game_data_hashmap*>(data.get())->data;
             }
-            static game_hashmap_type dummy;  //else we would return a temporary.
+            static rv_hashmap dummy;  //else we would return a temporary.
             dummy.clear();                   //In case user modified it before
             return dummy;
         }
@@ -899,44 +899,7 @@ namespace intercept {
         }
 
         size_t game_value::hash() const {
-            if (!data) return 0;
-
-            switch(type_enum()) {
-                case game_data_type::SCALAR: return reinterpret_cast<game_data_number*>(data.get())->hash();
-                case game_data_type::BOOL: return reinterpret_cast<game_data_bool*>(data.get())->hash();
-                case game_data_type::ARRAY: return reinterpret_cast<game_data_array*>(data.get())->hash();
-                case game_data_type::STRING: return reinterpret_cast<game_data_string*>(data.get())->hash();
-                case game_data_type::NOTHING: return reinterpret_cast<game_data*>(data.get())->to_string().hash();
-                case game_data_type::NAMESPACE: return reinterpret_cast<game_data_namespace*>(data.get())->hash();
-                case game_data_type::NaN: return reinterpret_cast<game_data*>(data.get())->to_string().hash();
-                case game_data_type::CODE: return reinterpret_cast<game_data_code*>(data.get())->hash();
-                case game_data_type::OBJECT: return reinterpret_cast<game_data_object*>(data.get())->hash();
-                case game_data_type::SIDE: return reinterpret_cast<game_data_side*>(data.get())->hash();
-                case game_data_type::GROUP: return reinterpret_cast<game_data_group*>(data.get())->hash();
-                case game_data_type::TEXT: return reinterpret_cast<game_data_rv_text*>(data.get())->hash();
-                case game_data_type::SCRIPT: return reinterpret_cast<game_data_script*>(data.get())->hash();
-                case game_data_type::TARGET: return reinterpret_cast<game_data*>(data.get())->to_string().hash();
-                case game_data_type::CONFIG: return reinterpret_cast<game_data_config*>(data.get())->hash();
-                case game_data_type::DISPLAY: return reinterpret_cast<game_data_display*>(data.get())->hash();
-                case game_data_type::CONTROL: return reinterpret_cast<game_data_control*>(data.get())->hash();
-#if defined(_DEBUG) && defined(_MSC_VER)
-                //If you encounter any of these give Dedmen a repro.
-                case game_data_type::ANY: __debugbreak(); break;//ANY should never be seen as a value.
-                case game_data_type::NetObject: __debugbreak(); break;
-                case game_data_type::SUBGROUP: __debugbreak(); break;
-#else
-                case game_data_type::ANY: return 0;
-                case game_data_type::NetObject: return 0;
-                case game_data_type::SUBGROUP: return 0;
-#endif
-                case game_data_type::TEAM_MEMBER: return reinterpret_cast<game_data_team_member*>(data.get())->hash();
-                case game_data_type::TASK: return reinterpret_cast<game_data*>(data.get())->to_string().hash(); //"Task %s (id %d)" or "No Task"
-                case game_data_type::DIARY_RECORD: return reinterpret_cast<game_data*>(data.get())->to_string().hash(); //"No diary record" or... The text of that record? Text might be long and make this hash heavy
-                case game_data_type::LOCATION: return reinterpret_cast<game_data_location*>(data.get())->hash();
-                case game_data_type::end: return 0;
-            }
-
-            return types::__internal::pairhash<uintptr_t,uintptr_t>(data->get_vtable(),reinterpret_cast<uintptr_t>(data.get()));
+            return get_hash();
         }
 
         void* game_value::operator new(const std::size_t sz_) {

--- a/src/client/intercept/shared/types.cpp
+++ b/src/client/intercept/shared/types.cpp
@@ -894,7 +894,7 @@ namespace intercept {
 
         uint64_t game_value::get_hash() const {
             if (!data)
-                return 0XCBF29CE484222325; //64bit FNV-1 offset basis
+                return 0xCBF29CE484222325; //64bit FNV-1 offset basis
             return data.get()->get_hash();
         }
 

--- a/src/client/intercept/shared/types.cpp
+++ b/src/client/intercept/shared/types.cpp
@@ -894,11 +894,11 @@ namespace intercept {
 
         uint64_t game_value::get_hash() const {
             if (!data)
-                return 0;
+                return 0XCBF29CE484222325; //64bit FNV-1 offset basis
             return data.get()->get_hash();
         }
 
-        size_t game_value::hash() const {
+        uint64_t game_value::hash() const {
             return get_hash();
         }
 

--- a/src/client/intercept/shared/types.cpp
+++ b/src/client/intercept/shared/types.cpp
@@ -898,10 +898,6 @@ namespace intercept {
             return data.get()->get_hash();
         }
 
-        uint64_t game_value::hash() const {
-            return get_hash();
-        }
-
         void* game_value::operator new(const std::size_t sz_) {
             return rv_allocator<game_value>::create_array(sz_);
         }

--- a/src/host/invoker/invoker.cpp
+++ b/src/host/invoker/invoker.cpp
@@ -308,6 +308,15 @@ namespace intercept {
         game_data_array::type_def = structure.first;
         game_data_array::data_type_def = structure.second;
         game_data_array::pool_alloc_base = loader::get().get_allocator()->_poolAllocs[static_cast<size_t>(types::game_data_type::ARRAY)];
+
+        ref<game_data> gd_hm(regInfo._types[static_cast<size_t>(GameDataType::HASHMAP)]->_createFunction(nullptr));
+        structure = {gd_hm->get_vtable(), gd_hm->get_secondary_vtable()};
+        invoker::get().type_map[structure.first] = "HASHMAP"sv;
+        invoker::get().type_structures["HASHMAP"sv] = structure;
+        game_data_hashmap::type_def = structure.first;
+        game_data_hashmap::data_type_def = structure.second;
+        game_data_hashmap::pool_alloc_base = loader::get().get_allocator()->_poolAllocs[static_cast<size_t>(types::game_data_type::HASHMAP)];
+
         ref<game_data> gd_sc(regInfo._types[static_cast<size_t>(GameDataType::SCALAR)]->_createFunction(nullptr));
         structure = { gd_sc->get_vtable(), gd_sc->get_secondary_vtable() };
         invoker::get().type_map[structure.first] = "SCALAR"sv;
@@ -315,6 +324,7 @@ namespace intercept {
         game_data_number::type_def = structure.first;
         game_data_number::data_type_def = structure.second;
         game_data_number::pool_alloc_base = loader::get().get_allocator()->_poolAllocs[static_cast<size_t>(types::game_data_type::SCALAR)];
+
         ref<game_data> gd_bo(regInfo._types[static_cast<size_t>(GameDataType::BOOL)]->_createFunction(nullptr));
         structure = { gd_bo->get_vtable(), gd_bo->get_secondary_vtable() };
         invoker::get().type_map[structure.first] = "BOOL"sv;
@@ -322,6 +332,7 @@ namespace intercept {
         game_data_bool::type_def = structure.first;
         game_data_bool::data_type_def = structure.second;
         game_data_bool::pool_alloc_base = loader::get().get_allocator()->_poolAllocs[static_cast<size_t>(types::game_data_type::BOOL)];
+
         ref<game_data> gd_st(regInfo._types[static_cast<size_t>(GameDataType::STRING)]->_createFunction(nullptr));
         structure = { gd_st->get_vtable(), gd_st->get_secondary_vtable() };
         invoker::get().type_map[structure.first] = "STRING"sv;
@@ -329,6 +340,7 @@ namespace intercept {
         game_data_string::type_def = structure.first;
         game_data_string::data_type_def = structure.second;
         game_data_string::pool_alloc_base = loader::get().get_allocator()->_poolAllocs[static_cast<size_t>(types::game_data_type::STRING)];
+
         ref<game_data> gd_code(regInfo._types[static_cast<size_t>(GameDataType::CODE)]->_createFunction(nullptr));
         structure = { gd_code->get_vtable(), gd_code->get_secondary_vtable() };
         invoker::get().type_map[structure.first] = "CODE"sv;
@@ -336,60 +348,70 @@ namespace intercept {
         game_data_code::type_def = structure.first;
         game_data_code::data_type_def = structure.second;
         game_data_code::pool_alloc_base = loader::get().get_allocator()->_poolAllocs[static_cast<size_t>(types::game_data_type::CODE)];
+
         ref<game_data> gd_ob(regInfo._types[static_cast<size_t>(GameDataType::OBJECT)]->_createFunction(nullptr));
         structure = { gd_ob->get_vtable(), gd_ob->get_secondary_vtable() };
         invoker::get().type_map[structure.first] = "OBJECT"sv;
         invoker::get().type_structures["OBJECT"sv] = structure;
         game_data_object::type_def = structure.first;
         game_data_object::data_type_def = structure.second;
+
         ref<game_data> gd_gr(regInfo._types[static_cast<size_t>(GameDataType::GROUP)]->_createFunction(nullptr));
         structure = { gd_gr->get_vtable(), gd_gr->get_secondary_vtable() };
         invoker::get().type_map[structure.first] = "GROUP"sv;
         invoker::get().type_structures["GROUP"sv] = structure;
         game_data_group::type_def = structure.first;
         game_data_group::data_type_def = structure.second;
+
         ref<game_data> gd_conf(regInfo._types[static_cast<size_t>(GameDataType::CONFIG)]->_createFunction(nullptr));
         structure = { gd_conf->get_vtable(), gd_conf->get_secondary_vtable() };
         invoker::get().type_map[structure.first] = "CONFIG"sv;
         invoker::get().type_structures["CONFIG"sv] = structure;
         game_data_config::type_def = structure.first;
         game_data_config::data_type_def = structure.second;
+
         ref<game_data> gd_cont(regInfo._types[static_cast<size_t>(GameDataType::CONTROL)]->_createFunction(nullptr));
         structure = { gd_cont->get_vtable(), gd_cont->get_secondary_vtable() };
         invoker::get().type_map[structure.first] = "CONTROL"sv;
         invoker::get().type_structures["CONTROL"sv] = structure;
         game_data_control::type_def = structure.first;
         game_data_control::data_type_def = structure.second;
+
         ref<game_data> gd_di(regInfo._types[static_cast<size_t>(GameDataType::DISPLAY)]->_createFunction(nullptr));
         structure = { gd_di->get_vtable(), gd_di->get_secondary_vtable() };
         invoker::get().type_map[structure.first] = "DISPLAY"sv;
         invoker::get().type_structures["DISPLAY"sv] = structure;
         game_data_display::type_def = structure.first;
         game_data_display::data_type_def = structure.second;
+
         ref<game_data> gd_loc(regInfo._types[static_cast<size_t>(GameDataType::LOCATION)]->_createFunction(nullptr));
         structure = { gd_loc->get_vtable(), gd_loc->get_secondary_vtable() };
         invoker::get().type_map[structure.first] = "LOCATION"sv;
         invoker::get().type_structures["LOCATION"sv] = structure;
         game_data_location::type_def = structure.first;
         game_data_location::data_type_def = structure.second;
+
         ref<game_data> gd_scr(regInfo._types[static_cast<size_t>(GameDataType::SCRIPT)]->_createFunction(nullptr));
         structure = { gd_scr->get_vtable(), gd_scr->get_secondary_vtable() };
         invoker::get().type_map[structure.first] = "SCRIPT"sv;
         invoker::get().type_structures["SCRIPT"sv] = structure;
         game_data_script::type_def = structure.first;
         game_data_script::data_type_def = structure.second;
+
         ref<game_data> gd_si(regInfo._types[static_cast<size_t>(GameDataType::SIDE)]->_createFunction(nullptr));
         structure = { gd_si->get_vtable(), gd_si->get_secondary_vtable() };
         invoker::get().type_map[structure.first] = "SIDE"sv;
         invoker::get().type_structures["SIDE"sv] = structure;
         game_data_side::type_def = structure.first;
         game_data_side::data_type_def = structure.second;
+
         ref<game_data> gd_te(regInfo._types[static_cast<size_t>(GameDataType::TEXT)]->_createFunction(nullptr));
         structure = { gd_te->get_vtable(), gd_te->get_secondary_vtable() };
         invoker::get().type_map[structure.first] = "TEXT"sv;
         invoker::get().type_structures["TEXT"sv] = structure;
         game_data_rv_text::type_def = structure.first;
         game_data_rv_text::data_type_def = structure.second;
+
         ref<game_data> gd_tm(regInfo._types[static_cast<size_t>(GameDataType::TEAM_MEMBER)]->_createFunction(nullptr));
         structure = { gd_tm->get_vtable(), gd_tm->get_secondary_vtable() };
         invoker::get().type_map[structure.first] = "TEAM_MEMBER"sv;


### PR DESCRIPTION
To-do: 
- [x] fix parameter name styles to conform to intercept's style (e.g. `var` -> `var_`)
- [x] add an ~~unordered_map~~ (created rv_hashmap for now; use with `__helper::__convert_to_hashmap`) conversion so we can return from commands
- [x] add missing sqf commands that returned hashmaps
- [x] ~~maybe rename `key` and `value` to `first` and `second`?~~ no need

Sample test (RSQF):
SQF:
```sqf
testFn "ppBloom"
```
```cpp
game_value test_fn(game_value_parameter _id) {
    auto vidOpts = get_video_options();
    for (auto& opt : vidOpts) {
        system_chat(str({ opt.key, opt.value }));
    }
    auto v = vidOpts.find(_id);
    if (v)
        return v->value;
    else
        return "not found";
}
```