### PR TITLE
Added new object types; defined enum flag operators; disable #pragma optimize for Clang

### DIFF
--- a/src/client/headers/shared/client_types.hpp
+++ b/src/client/headers/shared/client_types.hpp
@@ -490,8 +490,13 @@ namespace intercept {
             obj_type_temporary = 4,
             obj_type_vehicle = 8,
             obj_type_temp_veh = 16,
-            obj_type_land_decal = 32
+            obj_type_land_decal = 32,
+            obj_type_all = 63,
+            obj_type_all_inc_null = -1
         };
+#ifdef DEFINE_ENUM_FLAG_OPERATORS
+        DEFINE_ENUM_FLAG_OPERATORS(object_types)
+#endif
 
         enum class object_simulation_kind {
             Statics = 0,

--- a/src/client/headers/shared/types.hpp
+++ b/src/client/headers/shared/types.hpp
@@ -703,7 +703,7 @@ namespace intercept {
                 return *reinterpret_cast<const uintptr_t*>(this);
             }
 
-#ifndef _blalb
+#ifndef __clang__
 #pragma optimize("ts", on)
 #endif  // ! __clang__
             void set_vtable(uintptr_t vt) noexcept {

--- a/src/client/headers/shared/types.hpp
+++ b/src/client/headers/shared/types.hpp
@@ -562,13 +562,18 @@ namespace intercept {
                 copy(copy_);
             }
 
+// Clang says optimize pragma can only be used at file scope
+#ifndef  __clang__
 #pragma optimize("ts", on)
+#endif  // ! __clang__
             game_value(game_value&& move_) noexcept {
                 set_vtable(__vptr_def);  //Whatever vtable move_ has.. if it's different then it's wrong
                 data = nullptr;
                 data.swap(move_.data);
             }
+#ifndef __clang__
 #pragma optimize("", on)
+#endif  // ! __clang__
 
             //Conversions
             game_value(game_data* val_) noexcept {
@@ -697,11 +702,16 @@ namespace intercept {
             uintptr_t get_vtable() const noexcept {
                 return *reinterpret_cast<const uintptr_t*>(this);
             }
+
+#ifndef _blalb
 #pragma optimize("ts", on)
+#endif  // ! __clang__
             void set_vtable(uintptr_t vt) noexcept {
                 *reinterpret_cast<uintptr_t*>(this) = vt;
             }
+#ifndef __clang__
 #pragma optimize("", on)
+#endif  // ! __clang__
         };
 
         class game_value_static : public game_value {


### PR DESCRIPTION
I've also removed the optimize pragma for Clang. Because it produces this error:
```
intercept\src\client\headers\shared/types.hpp:713:17: error: '#pragma optimize' can only appear at file scope
#pragma optimize("", on)
                ^
```
Clang is used by the Visual Studio extension "Struct Layout", which I use a lot:
https://marketplace.visualstudio.com/items?itemName=RamonViladomat.StructLayout