### PR TITLE
Fix GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   mod:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: git checkout
         uses: actions/checkout@v2
@@ -22,7 +22,7 @@ jobs:
           path: releases/1.0.0/@intercept
 
   extension-linux:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: git checkout
         uses: actions/checkout@v2
@@ -70,7 +70,7 @@ jobs:
           path: build/win64/intercept/Release/intercept_x64.dll
 
   package:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs:
       - extension-linux
       - extension-windows

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   mod:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - name: git checkout
         uses: actions/checkout@v2
@@ -22,7 +22,7 @@ jobs:
           path: releases/1.0.0/@intercept
 
   extension-linux:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - name: git checkout
         uses: actions/checkout@v2
@@ -70,7 +70,7 @@ jobs:
           path: build/win64/intercept/Release/intercept_x64.dll
 
   package:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     needs:
       - extension-linux
       - extension-windows


### PR DESCRIPTION
Fixes the Linux build. Apparently Ubuntu 18.04 didn't work anymore. Also support for it expires soon. See:
https://en.wikipedia.org/wiki/Ubuntu_version_history#Table_of_versions
Maybe that's why?
Also `latest` didn't work either.
Anyway, changed it to v20.04 for now.

