### PR TITLE
Change loadlibraryW to loadLibraryExW for additional flags

### DIFF
--- a/src/host/extensions/extensions.cpp
+++ b/src/host/extensions/extensions.cpp
@@ -220,7 +220,8 @@ namespace intercept {
             return false;
         }
 #else
-        auto dllHandle = LoadLibraryW(full_path->c_str());
+        // LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR flag is needed, as the library may have dependencies in this directory to load
+        auto dllHandle = LoadLibraryExW(full_path->c_str(), NULL, LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR | LOAD_LIBRARY_SEARCH_DEFAULT_DIRS);
         if (!dllHandle) {
             invoker::get().invoke_raw("diag_log", fmt::format("Intercept: LoadLibrary() failed, e={} [{}]", GetLastError(), path_));
             LOG(ERROR, "LoadLibrary() failed, e={} [{}]", GetLastError(), path_);


### PR DESCRIPTION
# TLDR:
Changing to LoadLibraryExW allows for placing dependencies next to the plugin instead of next to the exe.

## Info
If a DLL has dependencies, we need a better mechanism to allow for those dependencies to be loaded rather than placing them next to the exe. [LoadLibraryExW](https://learn.microsoft.com/en-us/windows/win32/api/libloaderapi/nf-libloaderapi-loadlibraryexw) provides us with search flags that LoadLibrary does not offer. LoadLibrary failure for loading dependencies comes from the fact that we pass in a full path name to it. Windows doesn't attempt to locate the dependencies by searching a well-defined set of directories rather it follows safe dll [searching](https://learn.microsoft.com/en-us/windows/win32/dlls/dynamic-link-library-security). Now it is a good thing that we provided the full path as it is safer to load the dll, its just as stated earlier we need a way to load dll dependencies in a well-defined way. LoadLibraryExW provides that, by using two flags [LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR and LOAD_LIBRARY_SEARCH_DEFAULT_DIRS](https://learn.microsoft.com/en-us/windows/win32/api/libloaderapi/nf-libloaderapi-loadlibraryexw). The two flags now have this search order.

1. LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR. The folder that contains the DLL is searched. This folder is searched only for dependencies of the DLL to be loaded.

2. LOAD_LIBRARY_SEARCH_APPLICATION_DIR. The application folder is searched.

3. LOAD_LIBRARY_SEARCH_USER_DIRS. Paths explicitly added with the [AddDllDirectory](https://learn.microsoft.com/en-us/windows/win32/api/LibLoaderAPI/nf-libloaderapi-adddlldirectory) function or the [SetDllDirectory](https://learn.microsoft.com/en-us/windows/win32/api/Winbase/nf-winbase-setdlldirectorya) function are searched. If you add more than one path, then the order in which the paths are searched is unspecified.

4. LOAD_LIBRARY_SEARCH_SYSTEM32. The System folder is searched.

Example of use.
My plugin has a dependencies on gmp-10 as I am using CGAL for nearest neighbor search. My pre_start function allocates a new console, re-opens stdout, and calls my nearestNeighborTest function.
```
void intercept::pre_start()
{
    AllocConsole();
    FILE* fp = new FILE();
    freopen_s(&fp, "CONOUT$", "w", stdout);

    nearestNeighborTest();
}
```
### Tests
![dependencies](https://github.com/intercept/intercept/assets/8095345/d191871f-4f1d-4d83-99d6-42bddf4988a8)

I have placed the dependency next to my plugin.
![folderofdependencydll](https://github.com/intercept/intercept/assets/8095345/28e13598-498f-4cbc-b39b-f7cfd183cb51)

### Failure
Now I launch Arma 3 with the current master branch intercept. And it fails, gmp is not loaded into the address space, my plugin isn't loaded and the rpt logs a failure.

![gmp-10_NOT_loaded_in_address_space_memory](https://github.com/intercept/intercept/assets/8095345/487d712f-0b86-4c95-bdc8-2a948e7e833b)
![failure_test](https://github.com/intercept/intercept/assets/8095345/3255033e-f9ff-4a9d-951f-309ac4b22807)
![rpt_failure](https://github.com/intercept/intercept/assets/8095345/9489fe4e-26ab-442f-8e2d-b3bb07dfedb0)

### Success
Now I switch to LoadLibraryExW and repeat the process. Lo and behold my plugin loads with it's dependency and displays the nearest neighbor.

![gmp-10_loaded_in_address_space_memory](https://github.com/intercept/intercept/assets/8095345/480b737e-f113-4fc8-bf89-a36c0084c568)
![confirmed_test](https://github.com/intercept/intercept/assets/8095345/0c1ec534-8902-41d5-8e27-a629e558fc06)

### Prior Arts

- Google uses this approach in [chromium](https://chromium.googlesource.com/chromium/src/+/HEAD/base/native_library_win.cc#76) to load dlls.
- Boost's [winapi](https://www.boost.org/doc/libs/1_71_0/boost/winapi/dll.hpp) exposes LoadLibraryExw too.

### Additional Knowledge
LoadLibraryExW has a flag to only load signed dlls LOAD_LIBRARY_REQUIRE_SIGNED_TARGET, dlls will need to be created with /INTEGRITYCHECK linked. This does not support windows 7, rather windows 8.1+.