### PR TITLE
Bump minimum CMake version to avoid deprecation warning in CMake 4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.8)
+cmake_minimum_required (VERSION 3.10)
 project (Intercept)
 
 set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/CMakeModules)

--- a/src/client/CMakeLists.txt
+++ b/src/client/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.8)
+cmake_minimum_required (VERSION 3.10)
 
 set_property(GLOBAL PROPERTY USE_FOLDERS ON) 
 

--- a/src/client/intercept/CMakeLists.txt
+++ b/src/client/intercept/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.8)
+cmake_minimum_required (VERSION 3.10)
 
 set(INTERCEPT_EXAMPLE_NAME "intercept_client")
 

--- a/src/host/CMakeLists.txt
+++ b/src/host/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.8)
+cmake_minimum_required (VERSION 3.10)
 
 set_property(GLOBAL PROPERTY USE_FOLDERS ON) 
 

--- a/src/host/intercept_dll/CMakeLists.txt
+++ b/src/host/intercept_dll/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.8)
+cmake_minimum_required (VERSION 3.10)
 
 if(USE_64BIT_BUILD)
     set(INTERCEPT_EXTENSION_NAME "intercept_x64")


### PR DESCRIPTION
```
CMake Deprecation Warning at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.10 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.
```